### PR TITLE
Make Railway production deployment reliable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,41 @@
-# Production-ready Dockerfile for LyoApp Backend - STABILIZED
-FROM python:3.11-slim as builder
+# Production container for the Lyo backend
+FROM python:3.11-slim AS builder
 
-# Install system dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     libpq-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create virtual environment
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy requirements and install dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Production stage
 FROM python:3.11-slim
 
-# Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
 RUN useradd --create-home --shell /bin/bash app
-
-# Copy virtual environment
 COPY --from=builder /opt/venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
 
-# Set working directory
-WORKDIR /app
-
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1 \
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app
 
-# --- CACHE BUSTER START ---
-# This forces Railway to re-copy all files even if it thinks nothing changed
-RUN echo "Fresh Build Triggered at: $(date)" > /build_timestamp.txt
-# --- CACHE BUSTER END ---
-
-# Copy application code
+WORKDIR /app
 COPY --chown=app:app . .
 
-# Health check (very generous start period)
-HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=5 \
-    CMD curl -f http://localhost:${PORT:-8080}/health || exit 1
+RUN mkdir -p uploads/avatars uploads/documents uploads/temp \
+    && chown -R app:app uploads
 
-# Create uploads directory
-RUN mkdir -p uploads/avatars uploads/documents uploads/temp && chown -R app:app uploads
-
-# Switch to non-root user
 USER app
 
-# Start application using the STABILIZED bootloader
-CMD ["bash", "-c", "uvicorn lyo_app.STABILIZED_MAIN:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers"]
+# Run the real application. A deployment must fail if the real API cannot boot;
+# never substitute a health-only bootloader that can hide import/config failures.
+CMD ["bash", "-c", "exec uvicorn lyo_app.enhanced_main:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers --forwarded-allow-ips='*'"]

--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -1,0 +1,48 @@
+# Production deployment (Railway)
+
+Railway is the single production target for this repository.
+
+## Required Railway resources
+
+- One backend service connected to this repository's `main` branch
+- Railway PostgreSQL, exposed to the service as `DATABASE_URL`
+- Railway Redis, exposed to the service as `REDIS_URL`
+- A generated Railway domain initially; attach the production API domain only after health checks pass
+
+## Required variables
+
+Set these in Railway, never in Git or a local deployment script:
+
+- `ENVIRONMENT=production`
+- `DEBUG=false`
+- `SECRET_KEY` (at least 64 random characters)
+- `JWT_SECRET_KEY` (at least 64 random characters)
+- `DATABASE_URL` (provided by Railway PostgreSQL)
+- `REDIS_URL` (provided by Railway Redis)
+- `GEMINI_API_KEY` (a newly generated key; do not reuse the revoked key)
+- `GOOGLE_API_KEY` (set to the same new Gemini key only if legacy code still requires it)
+- `CORS_ORIGINS` (the exact web application origins, as a comma-separated list)
+
+Optional provider keys should be added only when their feature is enabled.
+
+## Deployment gate
+
+A deployment is successful only when all of the following are true:
+
+1. Railway reports the deployment Active.
+2. `GET /health` returns HTTP 200 from the real FastAPI application.
+3. `GET /docs` returns HTTP 200.
+4. A production smoke test can register or authenticate a test account.
+5. An authenticated AI chat request succeeds with the new Gemini key.
+6. Community and classroom read endpoints return non-5xx responses.
+
+The container now starts `lyo_app.enhanced_main:app` directly. If imports,
+database migrations, or required configuration fail, Railway will mark the
+deployment failed instead of accepting a health-only bootloader.
+
+## Domain cutover
+
+Keep clients on the generated Railway domain until the deployment gate passes.
+Then attach the production API hostname in Railway, configure the DNS record
+Railway provides, wait for TLS issuance, and update all web/iOS/Android base URLs
+to that one hostname.

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5


### PR DESCRIPTION
## What changed

- makes Railway the explicit production deployment target
- adds a deterministic `railway.toml` build, health-check, and restart policy
- starts the real FastAPI application directly instead of the health-only stabilized bootloader
- documents required Railway services, secrets, smoke tests, and domain cutover

## Root cause

The repository mixed Railway, Cloud Run, and AWS deployment paths. The GitHub production job did not actually deploy, and the Docker bootloader could return a healthy response even when the real API failed to load. This made failed deployments look successful and kept backend fixes invisible to clients.

## Required operator action

Before merging/deploying, add a **new** Gemini key in Railway as `GEMINI_API_KEY` (and `GOOGLE_API_KEY` only for legacy compatibility). Do not reuse the revoked key. Confirm Railway PostgreSQL and Redis are attached, and set the exact web origins in `CORS_ORIGINS`.

## Validation

Configuration and entrypoint were inspected against the current `main` branch. Live deployment validation requires Railway account access and the replacement Gemini credential; the smoke-test gate is documented in `PRODUCTION_DEPLOYMENT.md`.

## Summary by Sourcery

Align production deployment on Railway with deterministic container behavior and direct FastAPI startup.

New Features:
- Introduce a Railway deployment configuration file defining Docker-based build, health check path, and restart policy.
- Add explicit production deployment documentation for Railway resources, environment variables, smoke tests, and domain cutover.

Enhancements:
- Simplify and harden the Docker image by running the real FastAPI application entrypoint instead of a health-only bootloader and removing nonessential runtime tweaks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching the container entrypoint from a health-only bootloader to the full app changes failure modes at deploy time and exposes real startup/config/DB errors in production.
> 
> **Overview**
> Production is now **explicitly Railway-only**, with **`railway.toml`** wiring Dockerfile builds, **`/health`** checks (300s timeout), and **ON_FAILURE** restarts so failed boots surface as failed deployments.
> 
> The **Dockerfile** no longer uses the **`STABILIZED_MAIN`** health-only bootloader, build cache buster, or in-image **HEALTHCHECK**; the container **`exec`**s **`lyo_app.enhanced_main:app`** with proxy headers and **`forwarded-allow-ips='*'`**, so import/config/DB issues fail the deploy instead of returning a false-healthy stub.
> 
> **`PRODUCTION_DEPLOYMENT.md`** documents required Postgres/Redis, secrets (including new Gemini key), a multi-step deployment gate (health, docs, auth, AI chat, community/classroom reads), and domain cutover after the gate passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a74ca8863d0edb34a7456c9d02480d3cf656f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->