### PR TITLE
Make AI Classroom evidence-based guided mastery

### DIFF
--- a/lyo_app/ai_classroom/director_prompt.py
+++ b/lyo_app/ai_classroom/director_prompt.py
@@ -1,9 +1,9 @@
 CLASSROOM_DIRECTOR_PROMPT = """
 ## ROLE
 
-You are the lesson director for Lyo, an AI classroom on iOS for **adult learners** (target user: curious adults, roughly 25-45). You do not chat with the user. You script a short live class with a Teacher, three AI classmates, and Lyo — the user's persistent companion who travels with them across every subject.
+You are the lesson director for Lyo, an AI classroom for **adult learners** (target user: curious adults, roughly 25-45). You script a short live class led by a Teacher, with optional AI classmates and Lyo — the user's persistent companion.
 
-Your job is to make the class feel like a short, well-paced session with the best teacher the user has ever had. Paced for adult attention spans. Never juvenile. Never preachy.
+Your job is learning, not theater: make the learner understand and apply the stated objective. The Teacher leads. Visuals clarify. Questions collect useful evidence. Classmates appear only when they model reasoning, surface a likely misconception, or reduce shame after an error. Paced for adult attention spans. Never juvenile. Never preachy.
 
 ---
 
@@ -21,8 +21,8 @@ The snarky, boundary-testing student. Very smart but prefers to be a bit sarcast
 ### Rio (Funny)
 The wisecracker. Drops a one-liner to break tension. Lands the joke and moves on.
 
-### Zack (Dumb but earnest)
-Constantly confused. Asks the most basic, "dumb" questions so the user never feels stupid. Very earnest and tries hard, but needs things explained simply.
+### Zack (New but thoughtful)
+A sincere novice who asks plain-language questions that expose hidden assumptions. Never a caricature and never the target of a joke.
 
 ### Lyo — the user's companion (SPECIAL ROLE)
 
@@ -71,11 +71,11 @@ This product is for curious adults. Every voice in the room must respect that.
 
 ## VOICE & PACING RULES
 
-- The teacher never explains a concept directly when he can ask a question that surfaces it instead.
-- After any non-trivial question to the user, emit a `user_prompt` turn with `beat_seconds` 3-6. The app holds for the user; if no response, a classmate jumps in.
-- Use deliberate hesitations: "Hmm." "Wait — let me put it this way." "Okay, so..."
-- Maximum two short paragraphs of teacher speech before a classmate, the user, or a board action interrupts.
-- AI classmates make a wrong or partial answer about **1 in every 4 classmate turns.** The teacher corrects gently. This is the most important learning mechanic. Do not skip it.
+- The Teacher explains the concept clearly before asking the learner to produce an answer.
+- Use `user_prompt` only when the response will reveal understanding or help the learner retrieve an important idea. One meaningful check is better than many interruptions.
+- Use deliberate hesitations sparingly: "Hmm." "Wait — let me put it this way." "Okay, so..."
+- Break dense explanations with a relevant board action, example, comparison, or short pause.
+- AI classmates are optional. Never manufacture mistakes on a quota. If a classmate speaks, the turn must clarify reasoning or a realistic misconception.
 - **Lyo never makes a wrong answer.** Lyo isn't competing — Lyo is alongside.
 - No filler praise. No emoji in spoken lines.
 
@@ -84,10 +84,10 @@ This product is for curious adults. Every voice in the room must respect that.
 ## OPENING PROTOCOL — FIRST SESSION OF ANY COURSE
 
 1. Open with the user's name and a moment of warmth.
-2. **Skip every syllabus, learning objective, and welcome speech.**
-3. Hook with a real-world puzzle from the subject that surfaces a paradox or surprise in under 30 seconds.
-4. Cold-call the user with an impossible-to-fail question (yes/no or recall-from-life) inside the first 45 seconds.
-5. Let Maya and Sam carry the dialogue while the user warms up.
+2. Skip the syllabus, but state a brief learner-facing purpose: what the learner will be able to understand or do.
+3. Hook with a real-world puzzle from the subject that makes the objective matter.
+4. Teach the first useful idea before asking for input.
+5. The Teacher carries the explanation. Use at most one classmate during the opening, and only if pedagogically useful.
 6. Lyo is present from second one — in the reading pose, occasionally glancing up, then settling back.
 7. Before the bell, state the through-line in one sentence: *"That gap is what this whole course is about."*
 8. Assign tiny "noticing" homework — something the user can do without opening the app.
@@ -106,33 +106,44 @@ This product is for curious adults. Every voice in the room must respect that.
 
 ## INVISIBLE DIAGNOSTIC & ADAPTATION
 
-**You do NOT ask the user diagnostic questions** ("how confident are you," "what's your goal"). Goal context is captured at course creation, separately. Inside class, you adapt based on **observed behavior:**
+Do not ask broad diagnostic questions that repeat information collected at course creation. Adapt only from evidence included in the input state:
 
-- **Response speed** — fast confident answers signal a confident learner; long pauses signal uncertainty
-- **Vocabulary used** — technical terms in answers signal advanced; everyday words signal beginner
-- **Correctness across difficulty** — nailing harder questions = advance pace
-- **Input mode** — voice = engaged; tap-only = passive (slow down, ask more)
+- **learning_objective** — the non-negotiable destination for the scene
+- **user_level and learner_context** — established difficulty and durable preferences
+- **learner_signal** — confusion, low challenge, an incorrect answer, or a request for an example
+- **learner_question** — answer this directly before returning to the sequence
+- **mastery evidence** — correctness and prior attempts when provided
 
-After the user's first 2-3 responses, silently classify them into one of four levels:
+Never pretend to observe response speed, voice usage, vocabulary, emotion, or behavior that is absent from the input. If evidence is weak, teach at the stated level and use one concise checkpoint.
 
-- **beginner** — slower pace, more analogies, easier questions, more classmate scaffolding
-- **developing** — medium pace, mix of concrete and abstract, Maya jumps in to help
-- **comfortable** — faster pace, fewer explanations, Sam asks harder questions
-- **advanced** — fast pace, challenge mode, teacher skips basics
+Adapt continuously: confusion means a smaller step plus a worked example; low challenge means deeper transfer, not skipped foundations; an incorrect answer means diagnose and reteach; demonstrated mastery means advance.
 
-**Adapt continuously.** If a user starts strong but loses ground, drop a tier. If they surprise you, bump up.
-
-**Never announce the classification. Never gamify it. The adaptation is invisible.**
+Never announce or gamify the classification.
 
 ---
 
 ## CONTINUITY
 
-You will receive a `user_memory` block at the start of each session. Reference one personal detail naturally **if** it grounds an example in the user's real life. Don't force it.
+You may receive a `learner_context` block at the start of a session. Use a personal detail only when it genuinely improves the example. Never invent or force continuity.
 
 You will also receive `last_session_recap`. Open ongoing sessions by referencing it briefly.
 
 **Lyo, especially, should reference past sessions in a relational way:** *"ok so yesterday I almost got it backwards too"* — Lyo's continuity is what makes the user feel known across time.
+
+---
+
+## PEDAGOGICAL SPINE
+
+Every teaching scene follows this order unless the learner asks a direct question:
+
+1. Name the useful objective in one plain sentence.
+2. Explain one core idea accurately and concisely.
+3. Show a concrete worked example or visual representation.
+4. Contrast it with a likely misconception or boundary case.
+5. Give one short summary or retrieval cue.
+6. End ready for the server-controlled checkpoint; do not add repeated low-value questions.
+
+If the learner asks a direct question, answer it first, verify the answer serves the objective, then resume at the smallest sensible step.
 
 ---
 
@@ -209,8 +220,8 @@ Output **only** the JSON array. No commentary, no markdown fences, no explanatio
 ## HARD RULES (NEVER BREAK)
 
 - Never output anything outside the JSON array.
-- Never let a session exceed ~90 seconds of audio playback (roughly 20-25 turns).
-- Never let the teacher info-dump. Break long speech with classmates or board actions.
+- Never let a scene exceed ~90 seconds of audio playback (usually 10-16 purposeful turns).
+- Never let the teacher info-dump. Break dense speech with a relevant board action, example, comparison, or pause; classmates are optional.
 - Never skip the through-line statement before the bell.
 - Never use cutesy filler ("yay!", "amazing!", "great question!", "absolutely!").
 - Lyo never lectures, never explains concepts, never corrects the user.

--- a/lyo_app/ai_classroom/director_prompt.py
+++ b/lyo_app/ai_classroom/director_prompt.py
@@ -142,6 +142,10 @@ Every teaching scene follows this order unless the learner asks a direct questio
 4. Contrast it with a likely misconception or boundary case.
 5. Give one short summary or retrieval cue.
 6. End ready for the server-controlled checkpoint; do not add repeated low-value questions.
+7. Treat a correct multiple-choice answer as recognition evidence, not mastery. Mastery requires the server's later explanation/application check.
+8. When a misconception tag or remediation hint is supplied, address that exact reasoning error and no invented diagnosis.
+
+Learner modes are binding: solo keeps the Teacher and Lyo only; classroom permits optional peers; challenge compresses exposition and deepens transfer; review begins with retrieval from due items. Honor the target duration through scope and depth, never filler.
 
 If the learner asks a direct question, answer it first, verify the answer serves the objective, then resume at the smallest sensible step.
 
@@ -194,8 +198,9 @@ Return a JSON array of turns. Each turn is exactly one of these shapes:
 - When a concept has a physical, visual referent (an organism, organ, machine, place, artwork, historical figure, structure), emit a board image turn with a precise 3-6 word encyclopedic query. Use at most 2 image turns per session.
 - When summarizing steps or key takeaways, prefer a board bullets turn over reading a list aloud.
 - When comparing quantities or showing change over time, emit a board chart turn with real illustrative numbers.
-- When a quantitative relationship has 1-2 parameters the learner could FEEL (growth rates, slopes, frequencies, interest), emit a board explorable turn — the learner manipulates sliders and watches the curve respond. This is the single most engaging thing you can put on the board; use it whenever the topic is quantitative. Expressions may use x, the named params, + - * / ^ ( ), and sin/cos/tan/exp/log/sqrt/abs.
+- Use a board explorable only when changing 1-2 parameters reveals a relationship central to the objective. Its prompt must ask for a prediction or explanation after manipulation; never add one as decoration. Expressions may use x, the named params, + - * / ^ ( ), and sin/cos/tan/exp/log/sqrt/abs.
 - The teacher should VERBALLY REFER to what's on the board ("look at how the curve bends here...") so speech and board feel like one performance.
+- Never invent a citation or claim live web research. Source attribution comes from the server's course material metadata.
 
 { "type": "ambient",
   "sound": "page_turn" | "chair_scrape" | "soft_laugh" | "bell" }

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -869,6 +869,14 @@ class ClassroomDirector:
                     require_audio=True,
                 )
 
+            if action_intent == ActionIntent.USER_MESSAGE:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning="Use the learner's response as evidence and continue the explanation",
+                    confidence=0.85,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                )
+
             if action_intent == ActionIntent.REQUEST_EXAMPLE:
                 return DirectorDecision(
                     selected_scene_type=SceneType.INSTRUCTION,

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -32,7 +32,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from lyo_app.ai_classroom.sdui_models import (
     Scene, SceneType, Component, ComponentType,
     TeacherMessage, StudentPrompt, QuizCard, CTAButton, Celebration, ProgressBar,
-    AudioMood, ActionIntent, WebSocketPayload, SceneStreamPayload,
+    InputField, LessonBlock, ExampleBlock,
+    AudioMood, ActionIntent, ClassroomMode, HintLevel, WebSocketPayload, SceneStreamPayload,
     UserActionPayload, SystemStatePayload, SceneMetadata
 )
 
@@ -41,6 +42,45 @@ logger = logging.getLogger(__name__)
 # Per-session teaching progression: scene counter + rolling summaries of what
 # was already taught, so the director never replays the opening scene.
 _SESSION_PROGRESS: Dict[str, Dict[str, Any]] = {}
+
+_TRANSFER_STOPWORDS = {
+    "about", "after", "again", "apply", "because", "before", "being", "compare",
+    "course", "demonstrate", "explain", "from", "have", "into", "lesson", "that",
+    "their", "there", "these", "this", "through", "understand", "using", "what",
+    "when", "where", "which", "with", "would", "your",
+}
+
+
+def expected_transfer_keywords(objective: str, lesson_content: str = "") -> List[str]:
+    """Build a small transparent rubric from authored course language."""
+    source = f"{objective} {lesson_content[:400]}"
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z0-9'-]{2,}", source.lower())
+    keywords: List[str] = []
+    for token in tokens:
+        if token in _TRANSFER_STOPWORDS or token in keywords:
+            continue
+        keywords.append(token)
+        if len(keywords) == 8:
+            break
+    return keywords
+
+
+def score_transfer_response(
+    response: str,
+    expected_keywords: List[str],
+    min_words: int = 6,
+    min_score: float = 0.25,
+) -> tuple[bool, float, List[str]]:
+    """Score open evidence deterministically; return correctness, coverage, gaps."""
+    tokens = re.findall(r"[a-zA-Z][a-zA-Z0-9'-]{1,}", (response or "").lower())
+    token_set = set(tokens)
+    rubric = [k.lower().strip() for k in expected_keywords if k and k.strip()]
+    hits = [k for k in rubric if k in token_set or k in (response or "").lower()]
+    coverage = len(hits) / max(len(rubric), 1)
+    substantive = len(tokens) >= min_words
+    correct = substantive and (not rubric or coverage >= min_score)
+    missing = [k for k in rubric if k not in hits]
+    return correct, round(coverage, 3), missing[:4]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════════
@@ -184,12 +224,20 @@ class ContextSnapshot(BaseModel):
     total_lessons: int = 0
     learning_objective: Optional[str] = None
     course_complete: bool = False
+    classroom_mode: ClassroomMode = ClassroomMode.SOLO
+    target_duration_minutes: int = Field(default=10, ge=3, le=60)
+    source_attributions: List[str] = Field(default_factory=list)
+    review_due_items: List[str] = Field(default_factory=list)
 
     # Current learner input + durable personalization context
     learner_signal: Optional[str] = None
     learner_message: Optional[str] = None
     learner_response: Optional[str] = None
     learner_context: str = ""
+    hint_level: Optional[HintLevel] = None
+    misconception_tag: Optional[str] = None
+    remediation_hint: Optional[str] = None
+    answer_feedback: Optional[str] = None
 
     # Knowledge state
     knowledge_states: List[KnowledgeState] = Field(default_factory=list)
@@ -255,6 +303,12 @@ class ContextAssembler:
         # If lesson gave us a more specific topic, use it
         if context.lesson_title and not context.topic:
             context.topic = context.lesson_title
+        if context.course_title or context.lesson_title:
+            context.source_attributions = [
+                "Course material"
+                + (f": {context.course_title}" if context.course_title else "")
+                + (f" — {context.lesson_title}" if context.lesson_title else "")
+            ]
 
         # Preserve the instructional goal and learner-selected pace for the
         # entire classroom session. These values arrive on the welcome trigger
@@ -277,6 +331,44 @@ class ContextAssembler:
             progress.get("difficulty"), context.preferred_difficulty
         )
 
+        mode = action_data.get("mode")
+        if mode:
+            try:
+                progress["classroom_mode"] = ClassroomMode(str(mode).lower()).value
+            except ValueError:
+                progress["classroom_mode"] = ClassroomMode.SOLO.value
+        try:
+            context.classroom_mode = ClassroomMode(
+                progress.get("classroom_mode", ClassroomMode.SOLO.value)
+            )
+        except ValueError:
+            context.classroom_mode = ClassroomMode.SOLO
+
+        duration = action_data.get("duration_minutes")
+        if duration is not None:
+            try:
+                progress["target_duration_minutes"] = max(3, min(60, int(duration)))
+            except (TypeError, ValueError):
+                pass
+        context.target_duration_minutes = int(
+            progress.get("target_duration_minutes", context.target_duration_minutes)
+        )
+
+        hint_level = action_data.get("hint_level")
+        if hint_level:
+            try:
+                context.hint_level = HintLevel(str(hint_level))
+                hint_counts = progress.setdefault("hint_counts", {})
+                lesson_key = str(context.lesson_index)
+                hint_counts[lesson_key] = int(hint_counts.get(lesson_key, 0)) + 1
+            except ValueError:
+                context.hint_level = HintLevel.NUDGE
+
+        answer_data = action_data.get("answer_data", {})
+        context.misconception_tag = answer_data.get("misconception_tag")
+        context.remediation_hint = answer_data.get("remediation_hint")
+        context.answer_feedback = answer_data.get("feedback")
+
         raw_intent = action_data.get("source_intent") or action_data.get("action_intent")
         context.learner_signal = (
             raw_intent.value if isinstance(raw_intent, ActionIntent) else raw_intent
@@ -289,6 +381,8 @@ class ContextAssembler:
         context.learner_context = await self._get_learner_context(
             trigger.user_id, context.lesson_title or context.topic
         )
+        if context.classroom_mode == ClassroomMode.REVIEW:
+            context.review_due_items = await self._get_due_review_items(trigger.user_id)
 
         # Gather knowledge states
         context.knowledge_states = await self._get_knowledge_states(trigger.user_id)
@@ -579,6 +673,24 @@ class ContextAssembler:
 
         return lesson_title, lesson_content, total_lessons
 
+    async def _get_due_review_items(self, user_id: str) -> List[str]:
+        """Return scheduled retrieval items without blocking guest sessions."""
+        try:
+            user_id_int = int(user_id)
+            from lyo_app.personalization.service import PersonalizationEngine
+            return await PersonalizationEngine()._get_due_repetitions(
+                self.db, user_id_int
+            )
+        except (ValueError, TypeError):
+            return []
+        except Exception as exc:
+            logger.debug("Could not load spaced-repetition queue: %s", exc)
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+            return []
+
     async def _get_knowledge_states(self, user_id: str) -> List[KnowledgeState]:
         """Retrieve mastery from the canonical personalization model.
 
@@ -835,26 +947,30 @@ class ClassroomDirector:
         return decision
 
     async def _evaluate_scene_need(self, trigger: Trigger, context: ContextSnapshot) -> DirectorDecision:
-        """Choose the next pedagogical move in the guided mastery loop."""
+        """Choose the next pedagogical move in the evidence-based mastery loop."""
         action_data = trigger.action_data or {}
         action_intent = action_data.get("action_intent")
-        answer_correct = (
+        answer_data = action_data.get("answer_data", {})
+        quiz_correct = (
             action_intent == ActionIntent.SUBMIT_ANSWER
-            and action_data.get("answer_data", {}).get("is_correct") is True
+            and answer_data.get("is_correct") is True
         )
+        transfer_correct = (
+            action_intent == ActionIntent.SUBMIT_TRANSFER
+            and answer_data.get("is_correct") is True
+        )
+        newly_correct = quiz_correct or transfer_correct
 
-        # Do not turn a newly correct answer into another correction merely
-        # because the learner struggled on earlier attempts.
         if (
             context.frustration.frustration_score > 0.6
             and context.frustration.consecutive_failures >= 3
-            and not answer_correct
+            and not newly_correct
         ):
             return DirectorDecision(
                 selected_scene_type=SceneType.CORRECTION,
                 reasoning="Repeated misses require a smaller step and explicit reteaching",
                 confidence=0.9,
-                suggested_components=[ComponentType.STUDENT_PROMPT, ComponentType.TEACHER_MESSAGE],
+                suggested_components=[ComponentType.TEACHER_MESSAGE],
                 require_audio=True,
             )
 
@@ -872,9 +988,9 @@ class ClassroomDirector:
                 if context.course_complete:
                     return DirectorDecision(
                         selected_scene_type=SceneType.CELEBRATION,
-                        reasoning="All lesson checkpoints are mastered",
+                        reasoning="All lesson checkpoints have recognition and transfer evidence",
                         confidence=0.95,
-                        suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION],
+                        suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.LESSON_BLOCK],
                         estimated_duration_seconds=15,
                     )
                 if action_data.get("advanced_after_mastery"):
@@ -886,7 +1002,7 @@ class ClassroomDirector:
                     )
                 return DirectorDecision(
                     selected_scene_type=SceneType.CHALLENGE,
-                    reasoning="Check understanding before advancing",
+                    reasoning="Collect recognition evidence before transfer",
                     confidence=0.9,
                     suggested_components=[ComponentType.QUIZ_CARD],
                     require_interaction=True,
@@ -894,12 +1010,13 @@ class ClassroomDirector:
                 )
 
             if action_intent == ActionIntent.REQUEST_HINT:
+                hint = context.hint_level.value if context.hint_level else HintLevel.NUDGE.value
                 return DirectorDecision(
                     selected_scene_type=SceneType.INSTRUCTION,
-                    reasoning="Learner is confused - reteach with a smaller step and worked example",
-                    confidence=0.9,
-                    difficulty_adjustment=-0.2,
-                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    reasoning=f"Provide graduated help at the {hint} level",
+                    confidence=0.92,
+                    difficulty_adjustment=-0.1 if hint == HintLevel.NUDGE.value else -0.25,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.EXAMPLE_BLOCK],
                     require_audio=True,
                 )
 
@@ -925,57 +1042,100 @@ class ClassroomDirector:
                     selected_scene_type=SceneType.INSTRUCTION,
                     reasoning="Provide a concrete worked example",
                     confidence=0.9,
-                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.EXAMPLE_BLOCK],
                 )
 
             if action_intent == ActionIntent.SKIP_AHEAD:
                 return DirectorDecision(
                     selected_scene_type=SceneType.INSTRUCTION,
-                    reasoning="Learner reports low challenge - increase depth without skipping the objective",
+                    reasoning="Increase depth and transfer without skipping the objective",
                     confidence=0.85,
                     difficulty_adjustment=0.25,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                )
+
+            if action_intent in (ActionIntent.REQUEST_REVIEW, ActionIntent.SET_MODE):
+                if context.classroom_mode == ClassroomMode.REVIEW:
+                    return DirectorDecision(
+                        selected_scene_type=SceneType.CHALLENGE,
+                        reasoning="Run retrieval practice from the learner's due-review queue",
+                        confidence=0.9,
+                        suggested_components=[ComponentType.QUIZ_CARD],
+                        require_interaction=True,
+                    )
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning=f"Adopt the learner-selected {context.classroom_mode.value} format",
+                    confidence=0.9,
                     suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
                 )
 
             if action_intent == ActionIntent.RETRY:
                 return DirectorDecision(
                     selected_scene_type=SceneType.CHALLENGE,
-                    reasoning="Retry the checkpoint after correction",
+                    reasoning="Retry the recognition checkpoint after targeted correction",
                     confidence=0.9,
                     suggested_components=[ComponentType.QUIZ_CARD],
                     require_interaction=True,
                 )
 
             if action_intent == ActionIntent.SUBMIT_ANSWER:
-                if answer_correct:
+                if quiz_correct:
+                    return DirectorDecision(
+                        selected_scene_type=SceneType.REFLECTION,
+                        reasoning="Recognition passed; require explanation or application before mastery",
+                        confidence=0.97,
+                        suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.INPUT_FIELD],
+                        require_interaction=True,
+                        estimated_duration_seconds=60,
+                    )
+                return DirectorDecision(
+                    selected_scene_type=SceneType.CORRECTION,
+                    reasoning="Use the chosen distractor's misconception and remediation metadata",
+                    confidence=0.95,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    require_audio=True,
+                )
+
+            if action_intent == ActionIntent.SUBMIT_TRANSFER:
+                if transfer_correct:
                     return DirectorDecision(
                         selected_scene_type=SceneType.CELEBRATION,
-                        reasoning="Checkpoint passed - acknowledge mastery before advancing",
-                        confidence=0.95,
+                        reasoning="Recognition plus transfer evidence demonstrates lesson mastery",
+                        confidence=0.98,
                         suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION, ComponentType.CTA_BUTTON],
                         estimated_duration_seconds=12,
                     )
                 return DirectorDecision(
                     selected_scene_type=SceneType.CORRECTION,
-                    reasoning="Checkpoint missed - explain the misconception and retry",
-                    confidence=0.95,
-                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    reasoning="Transfer response needs one precise revision before mastery",
+                    confidence=0.96,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.INPUT_FIELD],
+                    require_interaction=True,
                     require_audio=True,
                 )
 
         if context.course_complete:
             return DirectorDecision(
                 selected_scene_type=SceneType.CELEBRATION,
-                reasoning="Persisted session shows every checkpoint complete",
+                reasoning="Persisted session shows every lesson has multiple forms of evidence",
                 confidence=0.95,
-                suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION],
+                suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.LESSON_BLOCK],
                 estimated_duration_seconds=15,
             )
 
         if trigger.trigger_type == TriggerType.SYSTEM_TIMEOUT:
+            if context.classroom_mode == ClassroomMode.REVIEW and context.review_due_items:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.CHALLENGE,
+                    reasoning="Open with a due spaced-retrieval item",
+                    confidence=0.9,
+                    suggested_components=[ComponentType.QUIZ_CARD],
+                    require_interaction=True,
+                )
             return DirectorDecision(
                 selected_scene_type=SceneType.INSTRUCTION,
-                reasoning="Open or re-engage the lesson with explicit teaching",
+                reasoning="Open or re-engage with explicit teaching",
                 confidence=0.8,
                 suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
                 require_audio=True,
@@ -1061,6 +1221,9 @@ class SceneCompiler:
         if decision.selected_scene_type == SceneType.INSTRUCTION:
             components.extend(await self._create_instruction_components(context))
 
+        elif decision.selected_scene_type == SceneType.REFLECTION:
+            components.extend(self._create_transfer_components(context))
+
         elif decision.selected_scene_type == SceneType.CHALLENGE:
             components.extend(await self._create_challenge_components(context))
 
@@ -1093,7 +1256,10 @@ class SceneCompiler:
         return components
 
     async def _create_instruction_components(self, context: ContextSnapshot) -> List[Component]:
-        """Create components for instruction scenes"""
+        """Create components for instruction scenes."""
+        if context.hint_level:
+            return self._create_hint_components(context)
+
         components = []
 
         # Main teacher message
@@ -1118,6 +1284,7 @@ class SceneCompiler:
                 emotion="encouraging",
                 audio_mood=AudioMood.CALM,
                 concept_tags=[context.topic or "current_topic"],
+                source_attributions=context.source_attributions,
                 priority=0,
                 delay_ms=0
             ))
@@ -1131,6 +1298,7 @@ class SceneCompiler:
                     emotion="encouraging",
                     audio_mood=AudioMood.CALM,
                     concept_tags=[context.topic or "current_topic"],
+                    source_attributions=context.source_attributions,
                     priority=idx,
                     delay_ms=delay
                 ))
@@ -1146,6 +1314,90 @@ class SceneCompiler:
 
         return components
 
+    def _create_hint_components(self, context: ContextSnapshot) -> List[Component]:
+        """Return the requested rung of the hint ladder without hiding the level."""
+        level = context.hint_level or HintLevel.NUDGE
+        objective = context.learning_objective or context.lesson_title or context.topic or "this idea"
+        remediation = context.remediation_hint or ""
+        guidance = {
+            HintLevel.NUDGE: f"Small nudge: identify the one rule that connects the question to {objective}.",
+            HintLevel.PRINCIPLE: f"Principle: state the governing idea behind {objective} before calculating or choosing.",
+            HintLevel.WORKED_STEP: f"First step: name the known information, then connect it to {objective}.",
+            HintLevel.FULL_EXAMPLE: f"Worked example: choose a simple case, apply {objective} one step at a time, and check the result.",
+            HintLevel.PREREQUISITE: f"Prerequisite review: define the key terms inside {objective}, then rebuild the relationship between them.",
+        }[level]
+        if remediation:
+            guidance = f"{guidance} Focus especially on: {remediation}"
+        components: List[Component] = [
+            TeacherMessage(
+                text=guidance,
+                emotion="thinking",
+                audio_mood=AudioMood.GENTLE,
+                concept_tags=[objective],
+                source_attributions=context.source_attributions,
+                priority=0,
+            )
+        ]
+        if level in (HintLevel.WORKED_STEP, HintLevel.FULL_EXAMPLE, HintLevel.PREREQUISITE):
+            components.append(ExampleBlock(
+                title={
+                    HintLevel.WORKED_STEP: "Start here",
+                    HintLevel.FULL_EXAMPLE: "Worked example",
+                    HintLevel.PREREQUISITE: "Foundation refresher",
+                }[level],
+                content=context.lesson_content[:1200] if context.lesson_content else guidance,
+                example_type="real_world",
+                interactive=level == HintLevel.FULL_EXAMPLE,
+                priority=1,
+            ))
+        components.append(CTAButton(
+            label="Try the checkpoint",
+            action_intent=ActionIntent.CONTINUE,
+            button_style="primary",
+            priority=100,
+        ))
+        return components
+
+    def _create_transfer_components(self, context: ContextSnapshot) -> List[Component]:
+        """Ask for explanation/application evidence after recognition succeeds."""
+        objective = context.learning_objective or context.lesson_title or context.topic or "the lesson idea"
+        keywords = expected_transfer_keywords(objective, context.lesson_content or "")
+        if context.classroom_mode == ClassroomMode.CHALLENGE:
+            question = (
+                f"Apply {objective} to a new or boundary case. Explain your reasoning "
+                "and name one condition where the idea would not apply."
+            )
+        elif context.classroom_mode == ClassroomMode.REVIEW:
+            question = f"Without looking back, explain {objective} and give one concrete example."
+        else:
+            question = (
+                f"In your own words, apply {objective} to a new example or situation. "
+                "Explain why your example works."
+            )
+        return [
+            TeacherMessage(
+                text="The choice shows recognition. One short application will show that the idea is usable.",
+                emotion="thinking",
+                audio_mood=AudioMood.CALM,
+                concept_tags=[objective],
+                source_attributions=context.source_attributions,
+                priority=0,
+            ),
+            InputField(
+                question=question,
+                placeholder="Explain and apply the idea…",
+                action_intent=ActionIntent.SUBMIT_TRANSFER,
+                concept_id=objective,
+                evidence_type="retrieval" if context.classroom_mode == ClassroomMode.REVIEW else "transfer",
+                expected_keywords=keywords,
+                min_words=6,
+                max_words=120,
+                min_score=0.25,
+                source_attributions=context.source_attributions,
+                priority=1,
+            ),
+        ]
+
     async def _create_challenge_components(self, context: ContextSnapshot) -> List[Component]:
         """Create components for challenge/quiz scenes"""
         components = []
@@ -1157,78 +1409,120 @@ class SceneCompiler:
         return components
 
     async def _create_correction_components(self, context: ContextSnapshot, trigger: Trigger) -> List[Component]:
-        """Create components for correction scenes"""
-        components = []
+        """Create precise remediation from the submitted evidence."""
+        components: List[Component] = []
 
-        # Check if we should include peer normalization
-        if context.frustration.consecutive_failures >= 2 and not context.peer_cooldown_active:
-            # Add AI peer to normalize the error
+        if (
+            context.classroom_mode == ClassroomMode.CLASSROOM
+            and context.frustration.consecutive_failures >= 2
+            and not context.peer_cooldown_active
+        ):
             components.append(StudentPrompt(
                 student_name="Sam",
-                text="I thought that too! These concepts can be tricky at first.",
+                text="That choice follows a common shortcut. Let's inspect exactly where it breaks.",
                 personality_trait="supportive",
                 purpose="normalize_error",
-                priority=0
+                priority=0,
             ))
 
-        # Reteach the missed idea rather than merely saying it was wrong.
-        if self.ai_service:
+        focus = context.remediation_hint or context.misconception_tag
+        feedback = context.answer_feedback
+        if feedback or focus:
+            correction_text = " ".join(
+                part for part in [
+                    feedback or "The response is close, but one link in the reasoning needs revision.",
+                    f"Focus on {focus}." if focus else "",
+                ] if part
+            )
+        elif self.ai_service:
             correction_text = await self._generate_instruction_content(context)
         else:
             correction_text = self._local_instruction_fallback(context)
+
         components.append(TeacherMessage(
             text=correction_text,
             emotion="concerned",
             audio_mood=AudioMood.GENTLE,
             concept_tags=[context.learning_objective or context.topic or "current_topic"],
-            priority=1
+            source_attributions=context.source_attributions,
+            priority=1,
         ))
 
-        # Try again button
-        components.append(CTAButton(
-            label="Try Again",
-            action_intent=ActionIntent.RETRY,
-            button_style="secondary",
-            priority=2
-        ))
+        action_intent = (trigger.action_data or {}).get("action_intent")
+        if action_intent == ActionIntent.SUBMIT_TRANSFER:
+            transfer_input = self._create_transfer_components(context)[-1]
+            transfer_input.question = (
+                f"Revise your application of {context.learning_objective or context.topic or 'the idea'}. "
+                + (
+                    f"Make sure you address {focus}."
+                    if focus
+                    else "Add the missing reasoning link and explain why the example works."
+                )
+            )
+            transfer_input.priority = 2
+            components.append(transfer_input)
+        else:
+            components.append(CTAButton(
+                label="Retry checkpoint",
+                action_intent=ActionIntent.RETRY,
+                button_style="secondary",
+                priority=2,
+            ))
 
         return components
 
     async def _create_celebration_components(self, context: ContextSnapshot) -> List[Component]:
-        """Create components for celebration scenes"""
-        components = []
+        """Close with evidence, a useful summary, and the next retrieval step."""
+        progress = _SESSION_PROGRESS.get(context.session_id, {})
+        covered = list(progress.get("covered", []))[-3:]
+        objective = context.learning_objective or context.lesson_title or context.topic or "this idea"
+        components: List[Component] = []
 
         if context.course_complete:
-            components.append(TeacherMessage(
-                text=(
-                    f"You completed {context.course_title or context.topic or 'this course'} "
-                    "and demonstrated the key ideas at every checkpoint. "
-                    "Review your notebook, then choose one idea to apply outside the classroom."
-                ),
-                emotion="excited",
-                audio_mood=AudioMood.ENCOURAGING,
-                priority=0,
-            ))
-            celebration_message = "Course complete — you earned this! 🎉"
+            message = (
+                f"You completed {context.course_title or context.topic or 'this course'}. "
+                "Each lesson now has both recognition and application evidence."
+            )
+            celebration_message = "Course mastery demonstrated"
         else:
-            components.append(TeacherMessage(
-                text=(
-                    f"Yes — that shows you understand "
-                    f"{context.learning_objective or context.lesson_title or context.topic or 'this idea'}."
-                ),
-                emotion="encouraging",
-                audio_mood=AudioMood.ENCOURAGING,
-                priority=0,
-            ))
-            celebration_message = "Checkpoint mastered! 🎉"
+            message = (
+                f"You recognized and applied {objective}. "
+                "That is stronger evidence than a correct choice alone."
+            )
+            celebration_message = "Lesson mastered"
 
+        components.append(TeacherMessage(
+            text=message,
+            emotion="excited",
+            audio_mood=AudioMood.ENCOURAGING,
+            concept_tags=[objective],
+            source_attributions=context.source_attributions,
+            priority=0,
+        ))
+
+        summary_items = covered or [
+            f"Objective: {objective}",
+            "Evidence: recognition plus explanation/application",
+            "Next: retrieve the idea again after spacing",
+        ]
+        components.append(LessonBlock(
+            block_type="summary",
+            block={
+                "title": "What you can now do",
+                "content": f"Use {objective} without relying on answer choices.",
+                "items": summary_items,
+                "source_attributions": context.source_attributions,
+                "retrieval_scheduled": True,
+            },
+            priority=1,
+        ))
         components.append(Celebration(
             message=celebration_message,
             celebration_type="standard",
             particle_effect="confetti",
             achievement_type="mastery",
             points_earned=10,
-            priority=1
+            priority=2,
         ))
 
         if not context.course_complete:
@@ -1236,7 +1530,7 @@ class SceneCompiler:
                 label="Next lesson",
                 action_intent=ActionIntent.CONTINUE,
                 button_style="primary",
-                priority=2
+                priority=3,
             ))
 
         return components
@@ -1286,10 +1580,16 @@ learner_context: {json.dumps(context.learner_context or "No stored learner prefe
 last_session_recap: {json.dumps(covered[-1] if covered else "")}
 already_covered: {json.dumps(covered)}
 user_level: "{user_level}"
+classroom_mode: "{context.classroom_mode.value}"
+target_duration_minutes: {context.target_duration_minutes}
 learning_objective: {json.dumps(context.learning_objective or context.lesson_title or topic)}
 learner_signal: {json.dumps(context.learner_signal or "")}
+hint_level: {json.dumps(context.hint_level.value if context.hint_level else "")}
+misconception_tag: {json.dumps(context.misconception_tag or "")}
+remediation_hint: {json.dumps(context.remediation_hint or "")}
 learner_question: {json.dumps(context.learner_message or "")}
 learner_response: {json.dumps(context.learner_response or "")}
+review_due_items: {json.dumps(context.review_due_items)}
 lesson_title: "{context.lesson_title or topic}"
 lesson_content: {json.dumps(context.lesson_content or "")}
 
@@ -1299,8 +1599,12 @@ TEACHING RESPONSE RULES:
 - If learner_response is present, acknowledge its reasoning briefly and use it as evidence; do not pretend it was a question.
 - If learner_signal is request_hint or confused, slow down, diagnose the likely gap, and use one worked example.
 - If learner_signal is skip_ahead or too_easy, increase depth and transfer difficulty; do not merely move on.
-- If learner_signal is incorrect_answer, explicitly explain the likely misconception, then show one worked example.
-- Use learner_context only when relevant. Never invent preferences or history.
+- If learner_signal is incorrect_answer, use misconception_tag and remediation_hint when present; never give generic correction.
+- If classroom_mode is solo, only the Teacher and Lyo may appear. If classroom, classmates remain optional and pedagogically necessary.
+- If classroom_mode is challenge, shorten explanation and deepen boundary/transfer cases. If review, prioritize retrieval over re-lecturing.
+- Match the target duration by choosing depth, not filler or speed.
+- Use an explorable only when changing a parameter exposes a relationship in the learning objective; always follow it with a prediction or explanation prompt.
+- Use learner_context only when relevant. Never invent preferences, observations, sources, or history.
 - Teach first. AI classmates are optional and may speak only when they clarify a misconception or model reasoning.
 
 PROGRESSION RULES (CRITICAL):
@@ -1535,7 +1839,11 @@ PROGRESSION RULES (CRITICAL):
         from lyo_app.core.ai_resilience import ai_resilience_manager
         import json as _json
 
-        topic = context.topic or "the current concept"
+        topic = (
+            context.review_due_items[0]
+            if context.classroom_mode == ClassroomMode.REVIEW and context.review_due_items
+            else context.topic or "the current concept"
+        )
         lesson_content = context.lesson_content or ""
 
         try:
@@ -1546,12 +1854,14 @@ PROGRESSION RULES (CRITICAL):
                 f"Lesson Content:\n{lesson_content}\n\n"
                 f"What the teacher just taught in class (test THIS material):\n{taught_context}\n\n"
                 f"The question must test understanding of the specific concepts described above — never a generic question.\n"
+                f"Each distractor must represent a plausible, distinct misconception. "
+                f"Give option-specific feedback and a remediation cue.\n"
                 f"Return ONLY valid JSON (no markdown) with this exact structure:\n"
                 f'{{"question": "...", "options": ['
-                f'{{"id": "a", "label": "...", "is_correct": false}}, '
-                f'{{"id": "b", "label": "...", "is_correct": true}}, '
-                f'{{"id": "c", "label": "...", "is_correct": false}}, '
-                f'{{"id": "d", "label": "...", "is_correct": false}}'
+                f'{{"id": "a", "label": "...", "is_correct": false, "feedback_correct": null, "feedback_incorrect": "...", "misconception_tag": "...", "remediation_hint": "..."}}, '
+                f'{{"id": "b", "label": "...", "is_correct": true, "feedback_correct": "...", "feedback_incorrect": null, "misconception_tag": null, "remediation_hint": null}}, '
+                f'{{"id": "c", "label": "...", "is_correct": false, "feedback_correct": null, "feedback_incorrect": "...", "misconception_tag": "...", "remediation_hint": "..."}}, '
+                f'{{"id": "d", "label": "...", "is_correct": false, "feedback_correct": null, "feedback_incorrect": "...", "misconception_tag": "...", "remediation_hint": "..."}}'
                 f']}}'
             )
 
@@ -1603,6 +1913,10 @@ PROGRESSION RULES (CRITICAL):
                     id=opt["id"],
                     label=opt["label"],
                     is_correct=opt.get("is_correct", False),
+                    feedback_correct=opt.get("feedback_correct"),
+                    feedback_incorrect=opt.get("feedback_incorrect"),
+                    misconception_tag=opt.get("misconception_tag"),
+                    remediation_hint=opt.get("remediation_hint"),
                 )
                 for opt in data["options"]
             ]
@@ -1618,11 +1932,38 @@ PROGRESSION RULES (CRITICAL):
             logger.error(f"❌ Resilient AI quiz generation failed, using fallback: {e}")
 
         # Fallback static question (only when AI is unavailable)
+        core = (lesson_content.strip().split(".")[0] or f"The lesson's stated relationship in {topic}")[:260]
         options = [
-            QuizOption(id="a", label=f"Understanding {topic}", is_correct=True),
-            QuizOption(id="b", label="Applying the concept", is_correct=False),
-            QuizOption(id="c", label="Reviewing the basics", is_correct=False),
-            QuizOption(id="d", label="None of the above", is_correct=False)
+            QuizOption(
+                id="a",
+                label=core,
+                is_correct=True,
+                feedback_correct="That matches the relationship taught in the lesson.",
+            ),
+            QuizOption(
+                id="b",
+                label=f"{topic} works only when every value is identical.",
+                is_correct=False,
+                feedback_incorrect="That adds an absolute condition the lesson did not establish.",
+                misconception_tag="overgeneralized_condition",
+                remediation_hint="Separate the core relationship from special cases.",
+            ),
+            QuizOption(
+                id="c",
+                label=f"{topic} is mainly a rule to memorize without reasoning.",
+                is_correct=False,
+                feedback_incorrect="The lesson treats the idea as a relationship you can explain and apply.",
+                misconception_tag="procedure_without_meaning",
+                remediation_hint="Reconnect the procedure to why it works.",
+            ),
+            QuizOption(
+                id="d",
+                label=f"{topic} cannot be applied outside the example shown.",
+                is_correct=False,
+                feedback_incorrect="A worked example illustrates the idea; it does not limit its use.",
+                misconception_tag="example_as_boundary",
+                remediation_hint="Identify which features of the example are essential.",
+            ),
         ]
         return QuizCard(
             question=f"Which of the following represents the core objective when studying {topic}?",
@@ -1708,8 +2049,13 @@ class SceneLifecycleEngine:
             durable_context.update({
                 "current_lesson_index": context.lesson_index,
                 "mastered_lessons": list(progress.get("mastered_lessons", [])),
+                "evidence": dict(progress.get("evidence", {})),
+                "hint_counts": dict(progress.get("hint_counts", {})),
+                "misconception_history": list(progress.get("misconception_history", []))[-12:],
                 "learning_objective": progress.get("learning_objective"),
                 "difficulty": progress.get("difficulty"),
+                "classroom_mode": progress.get("classroom_mode", ClassroomMode.SOLO.value),
+                "target_duration_minutes": progress.get("target_duration_minutes", 10),
                 "course_complete": context.course_complete,
                 "scene": progress.get("scene", 0),
                 "covered": list(progress.get("covered", []))[-8:],
@@ -1765,23 +2111,42 @@ class SceneLifecycleEngine:
             self.session_contexts[trigger.session_id] = context
             logger.debug(f"Phase 2 (Context): {len(context.knowledge_states)} concepts analyzed")
 
-            # Guided mastery gate: a correct checkpoint masters the current
-            # lesson; only the following Continue may advance to the next one.
+            # Guided mastery gate: recognition unlocks a transfer task; only
+            # recognition plus transfer marks a lesson as mastered.
             action_data = trigger.action_data or {}
             action_intent = action_data.get("action_intent")
+            answer_data = action_data.get("answer_data", {})
             progress = _SESSION_PROGRESS.setdefault(
                 trigger.session_id, {"scene": 0, "covered": [], "mastered_lessons": []}
             )
             mastered_lessons = set(progress.get("mastered_lessons", []))
+            evidence = progress.setdefault("evidence", {})
+            lesson_key = str(context.lesson_index)
+            lesson_evidence = evidence.setdefault(
+                lesson_key, {"recognition": False, "transfer": False}
+            )
 
             if action_intent == ActionIntent.SUBMIT_ANSWER:
-                answer_is_correct = (
-                    action_data.get("answer_data", {}).get("is_correct") is True
-                )
+                answer_is_correct = answer_data.get("is_correct") is True
                 context.learner_signal = (
                     "correct_answer" if answer_is_correct else "incorrect_answer"
                 )
-                if answer_is_correct:
+                lesson_evidence["recognition"] = answer_is_correct
+                if not answer_is_correct and answer_data.get("misconception_tag"):
+                    history = progress.setdefault("misconception_history", [])
+                    history.append({
+                        "lesson_index": context.lesson_index,
+                        "tag": answer_data.get("misconception_tag"),
+                        "at": datetime.utcnow().isoformat(),
+                    })
+
+            if action_intent == ActionIntent.SUBMIT_TRANSFER:
+                transfer_is_correct = answer_data.get("is_correct") is True
+                context.learner_signal = (
+                    "correct_transfer" if transfer_is_correct else "incorrect_transfer"
+                )
+                lesson_evidence["transfer"] = transfer_is_correct
+                if transfer_is_correct and lesson_evidence.get("recognition"):
                     mastered_lessons.add(context.lesson_index)
                     progress["mastered_lessons"] = sorted(mastered_lessons)
 
@@ -1796,6 +2161,11 @@ class SceneLifecycleEngine:
                             context.course_id, next_index
                         )
                     context.learning_objective = context.lesson_title or context.topic
+                    context.source_attributions = [
+                        "Course material"
+                        + (f": {context.course_title}" if context.course_title else "")
+                        + (f" — {context.lesson_title}" if context.lesson_title else "")
+                    ]
                     try:
                         from lyo_app.ai_classroom.conversation_flow import get_conversation_manager
                         conv_session = get_conversation_manager().get_session(trigger.session_id)
@@ -1803,7 +2173,7 @@ class SceneLifecycleEngine:
                             conv_session.current_lesson_index = next_index
                     except Exception:
                         pass
-                    logger.info(f"📖 Mastery gate advanced lesson to {next_index}")
+                    logger.info(f"📖 Evidence gate advanced lesson to {next_index}")
                 else:
                     context.course_complete = True
                     action_data["course_complete"] = True
@@ -1911,68 +2281,81 @@ class SceneLifecycleEngine:
         quiz_component_id: str,
         selected_option_id: str,
         is_correct: bool,
-        response_time_ms: int
+        response_time_ms: int,
     ) -> Scene:
-        """Public API: Handle quiz answer submission with server-side validation"""
-
-        # ── Server-side correctness check ────────────────────────────
-
-        # Look up the active QuizCard scene to validate the answer.
-        # The client-supplied `is_correct` is treated as a hint only;
-        # the authoritative answer lives in the scene's QuizCard options.
-        validated_correct = False  # fail closed if the authoritative scene is unavailable
+        """Validate a quiz server-side and preserve distractor diagnosis."""
+        validated_correct = False
         validated_skill_id = (
             self.session_contexts.get(session_id).learning_objective
             if self.session_contexts.get(session_id)
             else None
         )
+        selected_feedback = None
+        misconception_tag = None
+        remediation_hint = None
         active_scene = self.active_scenes.get(
             next(
-                (sid for sid, s in self.active_scenes.items()
-                 if any(c.component_id == quiz_component_id for c in s.components)),
-                None
+                (
+                    sid for sid, scene in self.active_scenes.items()
+                    if any(c.component_id == quiz_component_id for c in scene.components)
+                ),
+                None,
             )
         ) if self.active_scenes else None
 
         if active_scene:
             for comp in active_scene.components:
-                if comp.component_id == quiz_component_id and hasattr(comp, 'options'):
+                if comp.component_id == quiz_component_id and hasattr(comp, "options"):
                     validated_skill_id = getattr(comp, "concept_id", None) or validated_skill_id
-                    for opt in comp.options:
-                        if opt.id == selected_option_id:
-                            validated_correct = opt.is_correct
+                    for option in comp.options:
+                        if option.id == selected_option_id:
+                            validated_correct = option.is_correct
+                            selected_feedback = (
+                                option.feedback_correct
+                                if validated_correct
+                                else option.feedback_incorrect
+                            )
+                            misconception_tag = option.misconception_tag
+                            remediation_hint = option.remediation_hint
                             if validated_correct != is_correct:
                                 logger.warning(
-                                    f"⚠️ Quiz validation mismatch: client said "
-                                    f"is_correct={is_correct}, server says {validated_correct}"
+                                    "Quiz validation mismatch: client=%s server=%s",
+                                    is_correct,
+                                    validated_correct,
                                 )
                             break
                     break
 
-        # Persist the authoritative result in the same mastery model used by
-        # personalization and by ContextAssembler. Guest sessions remain ephemeral.
+        progress = _SESSION_PROGRESS.get(session_id, {})
+        session_context = self.session_contexts.get(session_id)
+        lesson_index = session_context.lesson_index if session_context else 0
+        hints_used = int(
+            progress.get("hint_counts", {}).get(str(lesson_index), 0)
+        )
+
         try:
             user_id_int = int(user_id)
+            from lyo_app.personalization.schemas import KnowledgeTraceRequest
             from lyo_app.personalization.service import PersonalizationEngine
-            await PersonalizationEngine().dkt.update_mastery(
+            await PersonalizationEngine().trace_knowledge(
                 self.db,
-                user_id_int,
-                validated_skill_id or "current_concept",
-                validated_correct,
-                max(response_time_ms / 1000.0, 1.0),
-                0,
+                KnowledgeTraceRequest(
+                    learner_id=str(user_id_int),
+                    skill_id=validated_skill_id or "current_concept",
+                    item_id=validated_skill_id or "current_concept",
+                    correct=validated_correct,
+                    time_taken_seconds=max(response_time_ms / 1000.0, 1.0),
+                    hints_used=hints_used,
+                ),
             )
         except (ValueError, TypeError):
             logger.debug("Guest quiz result is not persisted")
-        except Exception as e:
-            logger.warning(f"⚠️ Could not persist classroom mastery: {e}")
+        except Exception as exc:
+            logger.warning("Could not persist classroom recognition evidence: %s", exc)
             try:
                 await self.db.rollback()
             except Exception:
                 pass
-
-        # Determine frustration based on correctness and time
-        urgency = 7 if not validated_correct else 3
 
         trigger = Trigger(
             trigger_type=TriggerType.USER_ACTION,
@@ -1983,13 +2366,114 @@ class SceneLifecycleEngine:
                 "answer_data": {
                     "selected_option_id": selected_option_id,
                     "is_correct": validated_correct,
-                    "response_time_ms": response_time_ms
-                }
+                    "response_time_ms": response_time_ms,
+                    "feedback": selected_feedback,
+                    "misconception_tag": misconception_tag,
+                    "remediation_hint": remediation_hint,
+                },
             },
             component_id=quiz_component_id,
-            urgency=urgency
+            urgency=7 if not validated_correct else 3,
+        )
+        return await self.process_trigger(trigger)
+
+    async def handle_transfer_submission(
+        self,
+        user_id: str,
+        session_id: str,
+        input_component_id: str,
+        response: str,
+        response_time_ms: int = 0,
+    ) -> Scene:
+        """Score explanation/application evidence from the active server rubric."""
+        validated_correct = False
+        coverage = 0.0
+        missing: List[str] = []
+        skill_id = (
+            self.session_contexts.get(session_id).learning_objective
+            if self.session_contexts.get(session_id)
+            else "current_concept"
+        )
+        expected_keywords: List[str] = []
+        min_words = 6
+        min_score = 0.25
+
+        active_scene = self.active_scenes.get(
+            next(
+                (
+                    sid for sid, scene in self.active_scenes.items()
+                    if any(c.component_id == input_component_id for c in scene.components)
+                ),
+                None,
+            )
+        ) if self.active_scenes else None
+        if active_scene:
+            for comp in active_scene.components:
+                if isinstance(comp, InputField) and comp.component_id == input_component_id:
+                    skill_id = comp.concept_id or skill_id
+                    expected_keywords = list(comp.expected_keywords)
+                    min_words = comp.min_words
+                    min_score = comp.min_score
+                    validated_correct, coverage, missing = score_transfer_response(
+                        response,
+                        expected_keywords,
+                        min_words=min_words,
+                        min_score=min_score,
+                    )
+                    break
+
+        feedback = (
+            "Your explanation uses the lesson idea in a new situation."
+            if validated_correct
+            else (
+                "Add the missing reasoning link"
+                + (f" around {', '.join(missing)}" if missing else "")
+                + f". Aim for at least {min_words} words and explain why the example works."
+            )
         )
 
+        progress = _SESSION_PROGRESS.get(session_id, {})
+        session_context = self.session_contexts.get(session_id)
+        lesson_index = session_context.lesson_index if session_context else 0
+        hints_used = int(progress.get("hint_counts", {}).get(str(lesson_index), 0))
+        try:
+            user_id_int = int(user_id)
+            from lyo_app.personalization.service import PersonalizationEngine
+            await PersonalizationEngine().dkt.update_mastery(
+                self.db,
+                user_id_int,
+                skill_id or "current_concept",
+                validated_correct,
+                max(response_time_ms / 1000.0, 1.0),
+                hints_used,
+            )
+        except (ValueError, TypeError):
+            logger.debug("Guest transfer evidence is not persisted")
+        except Exception as exc:
+            logger.warning("Could not persist classroom transfer evidence: %s", exc)
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+
+        trigger = Trigger(
+            trigger_type=TriggerType.USER_ACTION,
+            user_id=user_id,
+            session_id=session_id,
+            action_data={
+                "action_intent": ActionIntent.SUBMIT_TRANSFER,
+                "message": response,
+                "answer_data": {
+                    "is_correct": validated_correct,
+                    "coverage": coverage,
+                    "missing_keywords": missing,
+                    "feedback": feedback,
+                    "remediation_hint": ", ".join(missing) if missing else None,
+                },
+            },
+            component_id=input_component_id,
+            urgency=6 if not validated_correct else 3,
+        )
         return await self.process_trigger(trigger)
 
     async def trigger_celebration(
@@ -2030,6 +2514,7 @@ __all__ = [
     "SceneLifecycleEngine",
     "TriggerType", "Trigger", "TriggerListener",
     "ContextSnapshot", "ContextAssembler",
+    "expected_transfer_keywords", "score_transfer_response",
     "ClassroomDirector", "DirectorDecision",
     "SceneCompiler"
 ]

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -1205,7 +1205,7 @@ class SceneCompiler:
                     "and demonstrated the key ideas at every checkpoint. "
                     "Review your notebook, then choose one idea to apply outside the classroom."
                 ),
-                emotion="celebrating",
+                emotion="excited",
                 audio_mood=AudioMood.ENCOURAGING,
                 priority=0,
             ))

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -182,6 +182,13 @@ class ContextSnapshot(BaseModel):
     lesson_title: Optional[str] = None
     lesson_content: Optional[str] = None
     total_lessons: int = 0
+    learning_objective: Optional[str] = None
+    course_complete: bool = False
+
+    # Current learner input + durable personalization context
+    learner_signal: Optional[str] = None
+    learner_message: Optional[str] = None
+    learner_context: str = ""
 
     # Knowledge state
     knowledge_states: List[KnowledgeState] = Field(default_factory=list)
@@ -233,6 +240,39 @@ class ContextAssembler:
         # If lesson gave us a more specific topic, use it
         if context.lesson_title and not context.topic:
             context.topic = context.lesson_title
+
+        # Preserve the instructional goal and learner-selected pace for the
+        # entire classroom session. These values arrive on the welcome trigger
+        # and must remain available on later WebSocket actions.
+        action_data = trigger.action_data or {}
+        progress = _SESSION_PROGRESS.setdefault(
+            trigger.session_id, {"scene": 0, "covered": [], "mastered_lessons": []}
+        )
+        explicit_objective = action_data.get("objective")
+        if explicit_objective:
+            progress["learning_objective"] = str(explicit_objective)
+        context.learning_objective = (
+            progress.get("learning_objective")
+            or context.lesson_title
+            or context.topic
+        )
+
+        difficulty = action_data.get("difficulty")
+        if difficulty:
+            progress["difficulty"] = str(difficulty).lower()
+        difficulty_map = {"beginner": 0.3, "intermediate": 0.6, "advanced": 0.85}
+        context.preferred_difficulty = difficulty_map.get(
+            progress.get("difficulty"), context.preferred_difficulty
+        )
+
+        raw_intent = action_data.get("source_intent") or action_data.get("action_intent")
+        context.learner_signal = (
+            raw_intent.value if isinstance(raw_intent, ActionIntent) else raw_intent
+        )
+        context.learner_message = action_data.get("message")
+        context.learner_context = await self._get_learner_context(
+            trigger.user_id, context.lesson_title or context.topic
+        )
 
         # Gather knowledge states
         context.knowledge_states = await self._get_knowledge_states(trigger.user_id)
@@ -497,29 +537,72 @@ class ContextAssembler:
         return lesson_title, lesson_content, total_lessons
 
     async def _get_knowledge_states(self, user_id: str) -> List[KnowledgeState]:
-        """Retrieve current mastery states from the mastery_states table"""
+        """Retrieve mastery from the canonical personalization model.
+
+        LearnerMastery is also written by quiz submission, so the live
+        classroom reads the same evidence that the rest of personalization
+        uses. Legacy classroom mastery remains a migration fallback.
+        """
+        try:
+            user_id_int = int(user_id)
+            from lyo_app.personalization.models import LearnerMastery
+            result = await self.db.execute(
+                select(LearnerMastery).where(LearnerMastery.user_id == user_id_int)
+            )
+            rows = result.scalars().all()
+            if rows:
+                return [
+                    KnowledgeState(
+                        concept_id=r.skill_id,
+                        mastery_level=r.mastery_level or 0.0,
+                        confidence=max(0.0, min(1.0, 1.0 - (r.uncertainty or 0.5))),
+                        total_attempts=r.attempts or 0,
+                        last_attempt=r.last_seen,
+                    )
+                    for r in rows
+                ]
+        except (ValueError, TypeError):
+            logger.debug("Guest classroom has no durable learner mastery")
+        except Exception as e:
+            logger.warning(f"⚠️ Could not query learner mastery: {e}")
+
         try:
             from lyo_app.ai_classroom.models import MasteryState as MasteryStateDB
             result = await self.db.execute(
                 select(MasteryStateDB).where(MasteryStateDB.user_id == user_id)
             )
             rows = result.scalars().all()
-            if rows:
-                return [
-                    KnowledgeState(
-                        concept_id=r.concept_id or r.objective_id or "unknown",
-                        mastery_level=r.mastery_score,
-                        confidence=r.confidence,
-                        consecutive_correct=r.correct_count,
-                        consecutive_incorrect=r.incorrect_count,
-                        total_attempts=r.attempts,
-                        last_attempt=r.last_seen,
-                    )
-                    for r in rows
-                ]
+            return [
+                KnowledgeState(
+                    concept_id=r.concept_id or r.objective_id or "unknown",
+                    mastery_level=r.mastery_score,
+                    confidence=r.confidence,
+                    consecutive_correct=r.correct_count,
+                    consecutive_incorrect=r.incorrect_count,
+                    total_attempts=r.attempts,
+                    last_attempt=r.last_seen,
+                )
+                for r in rows
+            ]
         except Exception as e:
-            logger.warning(f"⚠️ Could not query mastery states: {e}")
-        return []
+            logger.warning(f"⚠️ Could not query legacy mastery states: {e}")
+            return []
+
+    async def _get_learner_context(
+        self, user_id: str, current_skill: Optional[str]
+    ) -> str:
+        """Load durable learner preferences and relevant memory for teaching."""
+        try:
+            int(user_id)
+            from lyo_app.personalization.service import PersonalizationEngine
+            return await PersonalizationEngine().build_prompt_context(
+                self.db, user_id, current_skill=current_skill
+            )
+        except (ValueError, TypeError):
+            return ""
+        except Exception as e:
+            logger.debug(f"ℹ️ Could not build learner prompt context: {e}")
+            return ""
 
     async def _calculate_frustration(self, trigger: Trigger) -> FrustrationMetrics:
         """Calculate user frustration based on recent interactions"""
@@ -709,109 +792,140 @@ class ClassroomDirector:
         return decision
 
     async def _evaluate_scene_need(self, trigger: Trigger, context: ContextSnapshot) -> DirectorDecision:
-        """Core decision logic - this is where the magic happens"""
+        """Choose the next pedagogical move in the guided mastery loop."""
+        action_data = trigger.action_data or {}
+        action_intent = action_data.get("action_intent")
+        answer_correct = (
+            action_intent == ActionIntent.SUBMIT_ANSWER
+            and action_data.get("answer_data", {}).get("is_correct") is True
+        )
 
-        # PRIORITY 1: Handle high-frustration situations immediately
-        if context.frustration.frustration_score > 0.6:
-            if context.frustration.consecutive_failures >= 3:
-                return DirectorDecision(
-                    selected_scene_type=SceneType.CORRECTION,
-                    reasoning="High frustration with multiple failures - need peer normalization",
-                    confidence=0.9,
-                    suggested_components=[ComponentType.STUDENT_PROMPT, ComponentType.TEACHER_MESSAGE],
-                    require_audio=True
-                )
+        # Do not turn a newly correct answer into another correction merely
+        # because the learner struggled on earlier attempts.
+        if (
+            context.frustration.frustration_score > 0.6
+            and context.frustration.consecutive_failures >= 3
+            and not answer_correct
+        ):
+            return DirectorDecision(
+                selected_scene_type=SceneType.CORRECTION,
+                reasoning="Repeated misses require a smaller step and explicit reteaching",
+                confidence=0.9,
+                suggested_components=[ComponentType.STUDENT_PROMPT, ComponentType.TEACHER_MESSAGE],
+                require_audio=True,
+            )
 
-        # PRIORITY 2: Celebrate achievements to maintain motivation
         if trigger.trigger_type == TriggerType.ACHIEVEMENT_UNLOCK:
             return DirectorDecision(
                 selected_scene_type=SceneType.CELEBRATION,
                 reasoning="Achievement unlocked - reinforce success",
                 confidence=0.95,
                 suggested_components=[ComponentType.CELEBRATION, ComponentType.CTA_BUTTON],
-                estimated_duration_seconds=10
+                estimated_duration_seconds=10,
             )
 
-        # PRIORITY 3: Handle user actions based on context
         if trigger.trigger_type == TriggerType.USER_ACTION:
-            action_intent = trigger.action_data.get("action_intent") if trigger.action_data else None
-
             if action_intent == ActionIntent.CONTINUE:
-                # ── Lesson Progression ────────────────────────────────
-                # Every 3rd lesson → quiz to reinforce learning
-                if context.lesson_index > 0 and context.lesson_index % 3 == 0:
+                if context.course_complete:
                     return DirectorDecision(
-                        selected_scene_type=SceneType.CHALLENGE,
-                        reasoning=f"Quiz time after lesson {context.lesson_index}",
-                        confidence=0.85,
-                        suggested_components=[ComponentType.QUIZ_CARD],
-                        require_interaction=True,
-                        estimated_duration_seconds=45
+                        selected_scene_type=SceneType.CELEBRATION,
+                        reasoning="All lesson checkpoints are mastered",
+                        confidence=0.95,
+                        suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION],
+                        estimated_duration_seconds=15,
                     )
-                return DirectorDecision(
-                    selected_scene_type=SceneType.INSTRUCTION,
-                    reasoning=f"Continue to lesson {context.lesson_index}"
-                              + (f": {context.lesson_title}" if hasattr(context, 'lesson_title') and context.lesson_title else ""),
-                    confidence=0.8,
-                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON]
-                )
-
-            elif action_intent == ActionIntent.REQUEST_HINT:
-                # User is stuck - provide gentle guidance
-                return DirectorDecision(
-                    selected_scene_type=SceneType.INSTRUCTION,
-                    reasoning="User requested hint - provide scaffolding",
-                    confidence=0.8,
-                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
-                    require_audio=True
-                )
-
-            elif action_intent == ActionIntent.SUBMIT_ANSWER:
-                # Answer submitted - evaluate and respond
-                answer_data = trigger.action_data.get("answer_data", {})
-                if answer_data.get("is_correct"):
-                    # Correct answer - move forward or challenge
-                    if self._should_add_challenge(context):
-                        return DirectorDecision(
-                            selected_scene_type=SceneType.CHALLENGE,
-                            reasoning="Correct answer + high mastery - provide challenge",
-                            confidence=0.75,
-                            suggested_components=[ComponentType.QUIZ_CARD],
-                            require_interaction=True
-                        )
-                    else:
-                        return DirectorDecision(
-                            selected_scene_type=SceneType.INSTRUCTION,
-                            reasoning="Correct answer - continue instruction",
-                            confidence=0.8,
-                            suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON]
-                        )
-                else:
-                    # Incorrect answer - determine intervention level
+                if action_data.get("advanced_after_mastery"):
                     return DirectorDecision(
-                        selected_scene_type=SceneType.CORRECTION,
-                        reasoning="Incorrect answer - provide targeted correction",
-                        confidence=0.85,
+                        selected_scene_type=SceneType.INSTRUCTION,
+                        reasoning=f"Begin the next sequenced lesson: {context.lesson_title or context.topic}",
+                        confidence=0.9,
                         suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
-                        require_audio=True
                     )
+                return DirectorDecision(
+                    selected_scene_type=SceneType.CHALLENGE,
+                    reasoning="Check understanding before advancing",
+                    confidence=0.9,
+                    suggested_components=[ComponentType.QUIZ_CARD],
+                    require_interaction=True,
+                    estimated_duration_seconds=45,
+                )
 
-        # PRIORITY 4: Handle timeouts with gentle re-engagement
+            if action_intent == ActionIntent.REQUEST_HINT:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning="Learner is confused - reteach with a smaller step and worked example",
+                    confidence=0.9,
+                    difficulty_adjustment=-0.2,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    require_audio=True,
+                )
+
+            if action_intent == ActionIntent.ASK_QUESTION:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning="Answer the learner's question directly, then reconnect it to the objective",
+                    confidence=0.95,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    require_audio=True,
+                )
+
+            if action_intent == ActionIntent.REQUEST_EXAMPLE:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning="Provide a concrete worked example",
+                    confidence=0.9,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                )
+
+            if action_intent == ActionIntent.SKIP_AHEAD:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.INSTRUCTION,
+                    reasoning="Learner reports low challenge - increase depth without skipping the objective",
+                    confidence=0.85,
+                    difficulty_adjustment=0.25,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                )
+
+            if action_intent == ActionIntent.RETRY:
+                return DirectorDecision(
+                    selected_scene_type=SceneType.CHALLENGE,
+                    reasoning="Retry the checkpoint after correction",
+                    confidence=0.9,
+                    suggested_components=[ComponentType.QUIZ_CARD],
+                    require_interaction=True,
+                )
+
+            if action_intent == ActionIntent.SUBMIT_ANSWER:
+                if answer_correct:
+                    return DirectorDecision(
+                        selected_scene_type=SceneType.CELEBRATION,
+                        reasoning="Checkpoint passed - acknowledge mastery before advancing",
+                        confidence=0.95,
+                        suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION, ComponentType.CTA_BUTTON],
+                        estimated_duration_seconds=12,
+                    )
+                return DirectorDecision(
+                    selected_scene_type=SceneType.CORRECTION,
+                    reasoning="Checkpoint missed - explain the misconception and retry",
+                    confidence=0.95,
+                    suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
+                    require_audio=True,
+                )
+
         if trigger.trigger_type == TriggerType.SYSTEM_TIMEOUT:
             return DirectorDecision(
                 selected_scene_type=SceneType.INSTRUCTION,
-                reasoning="User inactive - gentle re-engagement",
-                confidence=0.6,
+                reasoning="Open or re-engage the lesson with explicit teaching",
+                confidence=0.8,
                 suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
-                require_audio=True
+                require_audio=True,
             )
 
-        # FALLBACK: Default instruction scene
         return DirectorDecision(
             selected_scene_type=SceneType.INSTRUCTION,
-            reasoning="Default instruction scene",
-            confidence=0.5,
-            suggested_components=[ComponentType.TEACHER_MESSAGE]
+            reasoning="Default guided instruction",
+            confidence=0.6,
+            suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CTA_BUTTON],
         )
 
     def _should_add_challenge(self, context: ContextSnapshot) -> bool:
@@ -1005,21 +1119,46 @@ class SceneCompiler:
         """Create components for celebration scenes"""
         components = []
 
+        if context.course_complete:
+            components.append(TeacherMessage(
+                text=(
+                    f"You completed {context.course_title or context.topic or 'this course'} "
+                    "and demonstrated the key ideas at every checkpoint. "
+                    "Review your notebook, then choose one idea to apply outside the classroom."
+                ),
+                emotion="celebrating",
+                audio_mood=AudioMood.UPBEAT,
+                priority=0,
+            ))
+            celebration_message = "Course complete — you earned this! 🎉"
+        else:
+            components.append(TeacherMessage(
+                text=(
+                    f"Yes — that shows you understand "
+                    f"{context.learning_objective or context.lesson_title or context.topic or 'this idea'}."
+                ),
+                emotion="encouraging",
+                audio_mood=AudioMood.UPBEAT,
+                priority=0,
+            ))
+            celebration_message = "Checkpoint mastered! 🎉"
+
         components.append(Celebration(
-            message="Excellent work! You're making great progress! 🎉",
+            message=celebration_message,
             celebration_type="standard",
             particle_effect="confetti",
-            achievement_type="streak",
+            achievement_type="mastery",
             points_earned=10,
-            priority=0
-        ))
-
-        components.append(CTAButton(
-            label="Keep Going!",
-            action_intent=ActionIntent.CONTINUE,
-            button_style="primary",
             priority=1
         ))
+
+        if not context.course_complete:
+            components.append(CTAButton(
+                label="Next lesson",
+                action_intent=ActionIntent.CONTINUE,
+                button_style="primary",
+                priority=2
+            ))
 
         return components
 
@@ -1034,6 +1173,15 @@ class SceneCompiler:
             course_title = context.course_title or topic
             session_number = context.lesson_index + 1
             user_name = "Learner"
+            avg_mastery = (
+                sum(k.mastery_level for k in context.knowledge_states)
+                / max(len(context.knowledge_states), 1)
+            )
+            user_level = (
+                "advanced" if max(avg_mastery, context.preferred_difficulty) >= 0.75
+                else "intermediate" if max(avg_mastery, context.preferred_difficulty) >= 0.5
+                else "beginner"
+            )
 
             logger.info(
                 f"📝 Generating instruction via AI Resilience Manager: lesson_title={context.lesson_title!r}, "
@@ -1055,12 +1203,23 @@ subject: "{course_title}"
 session_number: {session_number}
 scene_number: {scene_number}
 user_name: "{user_name}"
-user_memory: "Likes clear and concise explanations."
+learner_context: {json.dumps(context.learner_context or "No stored learner preferences yet.")}
 last_session_recap: {json.dumps(covered[-1] if covered else "")}
 already_covered: {json.dumps(covered)}
-user_level: "beginner"
+user_level: "{user_level}"
+learning_objective: {json.dumps(context.learning_objective or context.lesson_title or topic)}
+learner_signal: {json.dumps(context.learner_signal or "")}
+learner_question: {json.dumps(context.learner_message or "")}
 lesson_title: "{context.lesson_title or topic}"
 lesson_content: {json.dumps(context.lesson_content or "")}
+
+TEACHING RESPONSE RULES:
+- Keep the learning_objective visible in your reasoning and make every turn serve it.
+- If learner_question is present, answer it directly before resuming the sequence.
+- If learner_signal is request_hint or confused, slow down, diagnose the likely gap, and use one worked example.
+- If learner_signal is skip_ahead or too_easy, increase depth and transfer difficulty; do not merely move on.
+- Use learner_context only when relevant. Never invent preferences or history.
+- Teach first. AI classmates are optional and may speak only when they clarify a misconception or model reasoning.
 
 PROGRESSION RULES (CRITICAL):
 - scene_number 1 is the ONLY scene that may use the opening protocol.
@@ -1087,7 +1246,7 @@ PROGRESSION RULES (CRITICAL):
             # Call the resilient AI manager with Gemini and OpenAI fallbacks.
             response = await ai_resilience_manager.chat_completion(
                 messages=[
-                    {"role": "system", "content": "You are a world-class course designer. You script a live class utilizing the provided INPUT FORMAT. CRITICAL REQUIREMENT: You must read `lesson_title` and `lesson_content` from the input, and base the entire lesson and lecture script on that exact `lesson_content`! Teach this exact material step-by-step through a rich conversational flow with the cast. Ensure that Rio, Maya, Sam, Zack, and the Teacher discuss the actual concepts, facts, examples, and code snippets provided in the `lesson_content`. Do NOT invent generic lessons; teach the exact content. Return ONLY valid JSON containing a list of director turns. No prose, no markdown — pure JSON."},
+                    {"role": "system", "content": "You are a rigorous, warm classroom teacher. Teach the exact lesson_content toward the stated learning_objective. Respond directly to learner_question and learner_signal. Use explanation, a worked example, and a concise check for understanding. AI classmates are optional and must never displace the teacher or the learner. Use learner_context only when relevant. Return ONLY a valid, non-empty JSON list of director turns. No prose or markdown."},
                     {"role": "user", "content": prompt}
                 ],
                 # gpt-4o-mini first: the Gemini key is currently revoked
@@ -1465,6 +1624,52 @@ class SceneLifecycleEngine:
             self.session_contexts[trigger.session_id] = context
             logger.debug(f"Phase 2 (Context): {len(context.knowledge_states)} concepts analyzed")
 
+            # Guided mastery gate: a correct checkpoint masters the current
+            # lesson; only the following Continue may advance to the next one.
+            action_data = trigger.action_data or {}
+            action_intent = action_data.get("action_intent")
+            progress = _SESSION_PROGRESS.setdefault(
+                trigger.session_id, {"scene": 0, "covered": [], "mastered_lessons": []}
+            )
+            mastered_lessons = set(progress.get("mastered_lessons", []))
+
+            if (
+                action_intent == ActionIntent.SUBMIT_ANSWER
+                and action_data.get("answer_data", {}).get("is_correct") is True
+            ):
+                mastered_lessons.add(context.lesson_index)
+                progress["mastered_lessons"] = sorted(mastered_lessons)
+
+            if action_intent == ActionIntent.CONTINUE and context.lesson_index in mastered_lessons:
+                next_index = context.lesson_index + 1
+                if context.total_lessons > 0 and next_index < context.total_lessons:
+                    context.lesson_index = next_index
+                    self.session_lesson_indices[trigger.session_id] = next_index
+                    action_data["advanced_after_mastery"] = True
+                    context.lesson_title, context.lesson_content, context.total_lessons = \
+                        await self.context_assembler._resolve_current_lesson(
+                            context.course_id, next_index
+                        )
+                    context.learning_objective = context.lesson_title or context.topic
+                    try:
+                        from lyo_app.ai_classroom.conversation_flow import get_conversation_manager
+                        conv_session = get_conversation_manager().get_session(trigger.session_id)
+                        if conv_session:
+                            conv_session.current_lesson_index = next_index
+                    except Exception:
+                        pass
+                    logger.info(f"📖 Mastery gate advanced lesson to {next_index}")
+                else:
+                    context.course_complete = True
+                    action_data["course_complete"] = True
+                    logger.info("🏁 All available classroom lessons mastered")
+
+            context.overall_progress = min(
+                1.0,
+                len(mastered_lessons) / max(context.total_lessons, 1),
+            )
+            self.session_contexts[trigger.session_id] = context
+
             # PHASE 3: Director Decision (Decide)
             decision = await self.director.decide_scene(trigger, context)
             logger.debug(f"Phase 3 (Director): {decision.selected_scene_type} selected")
@@ -1478,36 +1683,7 @@ class SceneLifecycleEngine:
             if self.websocket_manager:
                 await self._stream_scene_to_client(scene, trigger.session_id)
 
-            # ── Lesson Progression: advance lesson_index on CONTINUE (skip quizzes) ──
-            if trigger.trigger_type == TriggerType.USER_ACTION:
-                action_intent = (trigger.action_data or {}).get("action_intent")
-                if action_intent == ActionIntent.CONTINUE and scene.scene_type != SceneType.CHALLENGE:
-                    old_idx = self.session_lesson_indices.get(trigger.session_id, 0)
-                    
-                    # Update from ConversationSession if it exists to be doubly robust
-                    try:
-                        from lyo_app.ai_classroom.conversation_flow import get_conversation_manager
-                        cm = get_conversation_manager()
-                        conv_session = cm.get_session(trigger.session_id)
-                        if conv_session:
-                            old_idx = max(old_idx, conv_session.current_lesson_index)
-                    except Exception:
-                        conv_session = None
-                    
-                    new_idx = old_idx + 1
-                    # Wrap around if we've passed the last lesson
-                    if context.total_lessons > 0 and new_idx >= context.total_lessons:
-                        new_idx = 0  # restart or could stop
-                        logger.info(f"📚 Course completed! Wrapping to lesson 0")
-                    self.session_lesson_indices[trigger.session_id] = new_idx
-                    logger.info(f"📖 Advanced lesson index: {old_idx} → {new_idx}")
-                    
-                    if conv_session:
-                        try:
-                            conv_session.current_lesson_index = new_idx
-                        except Exception:
-                            pass
-
+            total_time = (time.time() - start_time) * 1000
             total_time = (time.time() - start_time) * 1000
             logger.info(f"✅ LIFECYCLE COMPLETE: {scene.scene_id} in {total_time:.0f}ms")
 
@@ -1597,7 +1773,12 @@ class SceneLifecycleEngine:
         # Look up the active QuizCard scene to validate the answer.
         # The client-supplied `is_correct` is treated as a hint only;
         # the authoritative answer lives in the scene's QuizCard options.
-        validated_correct = is_correct  # fallback to client value
+        validated_correct = False  # fail closed if the authoritative scene is unavailable
+        validated_skill_id = (
+            self.session_contexts.get(session_id).learning_objective
+            if self.session_contexts.get(session_id)
+            else None
+        )
         active_scene = self.active_scenes.get(
             next(
                 (sid for sid, s in self.active_scenes.items()
@@ -1609,6 +1790,7 @@ class SceneLifecycleEngine:
         if active_scene:
             for comp in active_scene.components:
                 if comp.component_id == quiz_component_id and hasattr(comp, 'options'):
+                    validated_skill_id = getattr(comp, "concept_id", None) or validated_skill_id
                     for opt in comp.options:
                         if opt.id == selected_option_id:
                             validated_correct = opt.is_correct
@@ -1619,6 +1801,28 @@ class SceneLifecycleEngine:
                                 )
                             break
                     break
+
+        # Persist the authoritative result in the same mastery model used by
+        # personalization and by ContextAssembler. Guest sessions remain ephemeral.
+        try:
+            user_id_int = int(user_id)
+            from lyo_app.personalization.service import PersonalizationEngine
+            await PersonalizationEngine().dkt.update_mastery(
+                self.db,
+                user_id_int,
+                validated_skill_id or "current_concept",
+                validated_correct,
+                max(response_time_ms / 1000.0, 1.0),
+                0,
+            )
+        except (ValueError, TypeError):
+            logger.debug("Guest quiz result is not persisted")
+        except Exception as e:
+            logger.warning(f"⚠️ Could not persist classroom mastery: {e}")
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
 
         # Determine frustration based on correctness and time
         urgency = 7 if not validated_correct else 3

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -1206,7 +1206,7 @@ class SceneCompiler:
                     "Review your notebook, then choose one idea to apply outside the classroom."
                 ),
                 emotion="celebrating",
-                audio_mood=AudioMood.UPBEAT,
+                audio_mood=AudioMood.ENCOURAGING,
                 priority=0,
             ))
             celebration_message = "Course complete — you earned this! 🎉"
@@ -1217,7 +1217,7 @@ class SceneCompiler:
                     f"{context.learning_objective or context.lesson_title or context.topic or 'this idea'}."
                 ),
                 emotion="encouraging",
-                audio_mood=AudioMood.UPBEAT,
+                audio_mood=AudioMood.ENCOURAGING,
                 priority=0,
             ))
             celebration_message = "Checkpoint mastered! 🎉"

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -31,7 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from lyo_app.ai_classroom.sdui_models import (
     Scene, SceneType, Component, ComponentType,
-    TeacherMessage, StudentPrompt, QuizCard, CTAButton, Celebration,
+    TeacherMessage, StudentPrompt, QuizCard, CTAButton, Celebration, ProgressBar,
     AudioMood, ActionIntent, WebSocketPayload, SceneStreamPayload,
     UserActionPayload, SystemStatePayload, SceneMetadata
 )
@@ -1070,10 +1070,25 @@ class SceneCompiler:
         elif decision.selected_scene_type == SceneType.CELEBRATION:
             components.extend(await self._create_celebration_components(context))
 
-        # Always add progress indicator if not celebration
-        if decision.selected_scene_type != SceneType.CELEBRATION:
-            # Could add progress bar component here
-            pass
+        # Make advancement visible. A checkpoint counts only after the server
+        # has validated it and placed it in mastered_lessons.
+        progress = _SESSION_PROGRESS.get(context.session_id, {})
+        total = max(context.total_lessons, 1)
+        mastered_count = min(
+            total,
+            len(set(progress.get("mastered_lessons", []))),
+        )
+        if context.course_complete:
+            mastered_count = total
+        components.insert(0, ProgressBar(
+            current=mastered_count,
+            total=total,
+            show_percentage=True,
+            show_fraction=True,
+            label="Lesson mastery",
+            color_scheme="purple",
+            priority=0,
+        ))
 
         return components
 

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -2280,7 +2280,6 @@ class SceneLifecycleEngine:
         session_id: str,
         quiz_component_id: str,
         selected_option_id: str,
-        is_correct: bool,
         response_time_ms: int,
     ) -> Scene:
         """Validate a quiz server-side and preserve distractor diagnosis."""
@@ -2317,12 +2316,6 @@ class SceneLifecycleEngine:
                             )
                             misconception_tag = option.misconception_tag
                             remediation_hint = option.remediation_hint
-                            if validated_correct != is_correct:
-                                logger.warning(
-                                    "Quiz validation mismatch: client=%s server=%s",
-                                    is_correct,
-                                    validated_correct,
-                                )
                             break
                     break
 

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -1062,7 +1062,7 @@ class SceneCompiler:
 
         # Continue button
         components.append(CTAButton(
-            label="Continue",
+            label="Check understanding",
             action_intent=ActionIntent.CONTINUE,
             button_style="primary",
             priority=100,  # Ensure it comes last
@@ -1096,12 +1096,16 @@ class SceneCompiler:
                 priority=0
             ))
 
-        # Teacher correction
-        topic_hint = f" about {context.topic}" if context.topic else ""
+        # Reteach the missed idea rather than merely saying it was wrong.
+        if self.ai_service:
+            correction_text = await self._generate_instruction_content(context)
+        else:
+            correction_text = self._local_instruction_fallback(context)
         components.append(TeacherMessage(
-            text=f"Let me help clarify this concept{topic_hint} for you.",
+            text=correction_text,
             emotion="concerned",
             audio_mood=AudioMood.GENTLE,
+            concept_tags=[context.learning_objective or context.topic or "current_topic"],
             priority=1
         ))
 
@@ -1218,6 +1222,7 @@ TEACHING RESPONSE RULES:
 - If learner_question is present, answer it directly before resuming the sequence.
 - If learner_signal is request_hint or confused, slow down, diagnose the likely gap, and use one worked example.
 - If learner_signal is skip_ahead or too_easy, increase depth and transfer difficulty; do not merely move on.
+- If learner_signal is incorrect_answer, explicitly explain the likely misconception, then show one worked example.
 - Use learner_context only when relevant. Never invent preferences or history.
 - Teach first. AI classmates are optional and may speak only when they clarify a misconception or model reasoning.
 
@@ -1529,7 +1534,7 @@ PROGRESSION RULES (CRITICAL):
                 question=data["question"],
                 options=options,
                 allow_multiple_attempts=True,
-                concept_id=context.topic or "current_concept",
+                concept_id=context.learning_objective or context.topic or "current_concept",
             )
 
         except Exception as e:
@@ -1546,7 +1551,7 @@ PROGRESSION RULES (CRITICAL):
             question=f"Which of the following represents the core objective when studying {topic}?",
             options=options,
             allow_multiple_attempts=True,
-            concept_id=context.topic or "current_concept"
+            concept_id=context.learning_objective or context.topic or "current_concept"
         )
 
 
@@ -1633,12 +1638,16 @@ class SceneLifecycleEngine:
             )
             mastered_lessons = set(progress.get("mastered_lessons", []))
 
-            if (
-                action_intent == ActionIntent.SUBMIT_ANSWER
-                and action_data.get("answer_data", {}).get("is_correct") is True
-            ):
-                mastered_lessons.add(context.lesson_index)
-                progress["mastered_lessons"] = sorted(mastered_lessons)
+            if action_intent == ActionIntent.SUBMIT_ANSWER:
+                answer_is_correct = (
+                    action_data.get("answer_data", {}).get("is_correct") is True
+                )
+                context.learner_signal = (
+                    "correct_answer" if answer_is_correct else "incorrect_answer"
+                )
+                if answer_is_correct:
+                    mastered_lessons.add(context.lesson_index)
+                    progress["mastered_lessons"] = sorted(mastered_lessons)
 
             if action_intent == ActionIntent.CONTINUE and context.lesson_index in mastered_lessons:
                 next_index = context.lesson_index + 1
@@ -1683,7 +1692,6 @@ class SceneLifecycleEngine:
             if self.websocket_manager:
                 await self._stream_scene_to_client(scene, trigger.session_id)
 
-            total_time = (time.time() - start_time) * 1000
             total_time = (time.time() - start_time) * 1000
             logger.info(f"✅ LIFECYCLE COMPLETE: {scene.scene_id} in {total_time:.0f}ms")
 

--- a/lyo_app/ai_classroom/scene_lifecycle_engine.py
+++ b/lyo_app/ai_classroom/scene_lifecycle_engine.py
@@ -188,6 +188,7 @@ class ContextSnapshot(BaseModel):
     # Current learner input + durable personalization context
     learner_signal: Optional[str] = None
     learner_message: Optional[str] = None
+    learner_response: Optional[str] = None
     learner_context: str = ""
 
     # Knowledge state
@@ -234,6 +235,20 @@ class ContextAssembler:
         context.topic, context.course_id, context.course_title, context.lesson_index = \
             await self._resolve_topic(trigger)
 
+        # Hydrate guided-classroom position from the existing ClassroomSession
+        # JSON context. This survives worker restarts without a schema migration.
+        progress = _SESSION_PROGRESS.setdefault(
+            trigger.session_id, {"scene": 0, "covered": [], "mastered_lessons": []}
+        )
+        if not progress.get("_hydrated"):
+            persisted = await self._load_persisted_session_progress(trigger)
+            if persisted:
+                progress.update(persisted)
+            progress["_hydrated"] = True
+        if "current_lesson_index" in progress:
+            context.lesson_index = int(progress["current_lesson_index"] or 0)
+        context.course_complete = bool(progress.get("course_complete", False))
+
         # Resolve current lesson content from the DB
         context.lesson_title, context.lesson_content, context.total_lessons = \
             await self._resolve_current_lesson(context.course_id, context.lesson_index)
@@ -245,9 +260,6 @@ class ContextAssembler:
         # entire classroom session. These values arrive on the welcome trigger
         # and must remain available on later WebSocket actions.
         action_data = trigger.action_data or {}
-        progress = _SESSION_PROGRESS.setdefault(
-            trigger.session_id, {"scene": 0, "covered": [], "mastered_lessons": []}
-        )
         explicit_objective = action_data.get("objective")
         if explicit_objective:
             progress["learning_objective"] = str(explicit_objective)
@@ -269,7 +281,11 @@ class ContextAssembler:
         context.learner_signal = (
             raw_intent.value if isinstance(raw_intent, ActionIntent) else raw_intent
         )
-        context.learner_message = action_data.get("message")
+        message = action_data.get("message")
+        if context.learner_signal == ActionIntent.ASK_QUESTION.value:
+            context.learner_message = message
+        else:
+            context.learner_response = message
         context.learner_context = await self._get_learner_context(
             trigger.user_id, context.lesson_title or context.topic
         )
@@ -297,6 +313,33 @@ class ContextAssembler:
                    f"engagement={context.engagement_level:.2f}")
 
         return context
+
+    async def _load_persisted_session_progress(
+        self, trigger: Trigger
+    ) -> Dict[str, Any]:
+        """Load the latest durable guided-classroom state for this learner."""
+        try:
+            user_id = int(trigger.user_id)
+            from lyo_app.classroom.models import ClassroomSession
+            result = await self.db.execute(
+                select(ClassroomSession)
+                .where(
+                    and_(
+                        ClassroomSession.user_id == user_id,
+                        ClassroomSession.title == trigger.session_id,
+                        ClassroomSession.session_type == "guided_ai",
+                    )
+                )
+                .order_by(desc(ClassroomSession.updated_at))
+                .limit(1)
+            )
+            session = result.scalars().first()
+            return dict(session.context or {}) if session else {}
+        except (ValueError, TypeError):
+            return {}
+        except Exception as e:
+            logger.debug(f"ℹ️ Could not hydrate classroom progress: {e}")
+            return {}
 
     async def _resolve_topic(
         self, trigger: Trigger
@@ -920,6 +963,15 @@ class ClassroomDirector:
                     require_audio=True,
                 )
 
+        if context.course_complete:
+            return DirectorDecision(
+                selected_scene_type=SceneType.CELEBRATION,
+                reasoning="Persisted session shows every checkpoint complete",
+                confidence=0.95,
+                suggested_components=[ComponentType.TEACHER_MESSAGE, ComponentType.CELEBRATION],
+                estimated_duration_seconds=15,
+            )
+
         if trigger.trigger_type == TriggerType.SYSTEM_TIMEOUT:
             return DirectorDecision(
                 selected_scene_type=SceneType.INSTRUCTION,
@@ -1222,12 +1274,14 @@ user_level: "{user_level}"
 learning_objective: {json.dumps(context.learning_objective or context.lesson_title or topic)}
 learner_signal: {json.dumps(context.learner_signal or "")}
 learner_question: {json.dumps(context.learner_message or "")}
+learner_response: {json.dumps(context.learner_response or "")}
 lesson_title: "{context.lesson_title or topic}"
 lesson_content: {json.dumps(context.lesson_content or "")}
 
 TEACHING RESPONSE RULES:
 - Keep the learning_objective visible in your reasoning and make every turn serve it.
 - If learner_question is present, answer it directly before resuming the sequence.
+- If learner_response is present, acknowledge its reasoning briefly and use it as evidence; do not pretend it was a question.
 - If learner_signal is request_hint or confused, slow down, diagnose the likely gap, and use one worked example.
 - If learner_signal is skip_ahead or too_easy, increase depth and transfer difficulty; do not merely move on.
 - If learner_signal is incorrect_answer, explicitly explain the likely misconception, then show one worked example.
@@ -1259,7 +1313,7 @@ PROGRESSION RULES (CRITICAL):
             # Call the resilient AI manager with Gemini and OpenAI fallbacks.
             response = await ai_resilience_manager.chat_completion(
                 messages=[
-                    {"role": "system", "content": "You are a rigorous, warm classroom teacher. Teach the exact lesson_content toward the stated learning_objective. Respond directly to learner_question and learner_signal. Use explanation, a worked example, and a concise check for understanding. AI classmates are optional and must never displace the teacher or the learner. Use learner_context only when relevant. Return ONLY a valid, non-empty JSON list of director turns. No prose or markdown."},
+                    {"role": "system", "content": "You are a rigorous, warm classroom teacher. Teach the exact lesson_content toward the stated learning_objective. Respond directly to learner_question, learner_response, and learner_signal. Use explanation, a worked example, and a concise check for understanding. AI classmates are optional and must never displace the teacher or the learner. Use learner_context only when relevant. Return ONLY a valid, non-empty JSON list of director turns. No prose or markdown."},
                     {"role": "user", "content": prompt}
                 ],
                 # gpt-4o-mini first: the Gemini key is currently revoked
@@ -1602,6 +1656,65 @@ class SceneLifecycleEngine:
         # Register default handlers
         self._register_handlers()
 
+    async def _persist_session_progress(
+        self,
+        trigger: Trigger,
+        context: ContextSnapshot,
+        progress: Dict[str, Any],
+    ) -> None:
+        """Persist guided classroom position in ClassroomSession.context."""
+        try:
+            user_id = int(trigger.user_id)
+            from lyo_app.classroom.models import ClassroomSession
+            result = await self.db.execute(
+                select(ClassroomSession)
+                .where(
+                    and_(
+                        ClassroomSession.user_id == user_id,
+                        ClassroomSession.title == trigger.session_id,
+                        ClassroomSession.session_type == "guided_ai",
+                    )
+                )
+                .order_by(desc(ClassroomSession.updated_at))
+                .limit(1)
+            )
+            session = result.scalars().first()
+            if not session:
+                session = ClassroomSession(
+                    user_id=user_id,
+                    title=trigger.session_id,
+                    subject=context.topic,
+                    session_type="guided_ai",
+                    context={},
+                )
+                self.db.add(session)
+
+            durable_context = dict(session.context or {})
+            durable_context.update({
+                "current_lesson_index": context.lesson_index,
+                "mastered_lessons": list(progress.get("mastered_lessons", [])),
+                "learning_objective": progress.get("learning_objective"),
+                "difficulty": progress.get("difficulty"),
+                "course_complete": context.course_complete,
+                "scene": progress.get("scene", 0),
+                "covered": list(progress.get("covered", []))[-8:],
+            })
+            session.context = durable_context
+            session.subject = context.topic or session.subject
+            session.is_active = not context.course_complete
+            session.updated_at = datetime.utcnow()
+            if context.course_complete:
+                session.ended_at = datetime.utcnow()
+            await self.db.commit()
+        except (ValueError, TypeError):
+            return
+        except Exception as e:
+            logger.warning(f"⚠️ Could not persist classroom progress: {e}")
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+
     def _register_handlers(self):
         """Register default trigger handlers"""
         self.trigger_listener.register_handler(
@@ -1685,7 +1798,10 @@ class SceneLifecycleEngine:
                 1.0,
                 len(mastered_lessons) / max(context.total_lessons, 1),
             )
+            progress["current_lesson_index"] = context.lesson_index
+            progress["course_complete"] = context.course_complete
             self.session_contexts[trigger.session_id] = context
+            await self._persist_session_progress(trigger, context, progress)
 
             # PHASE 3: Director Decision (Decide)
             decision = await self.director.decide_scene(trigger, context)

--- a/lyo_app/ai_classroom/sdui_models.py
+++ b/lyo_app/ai_classroom/sdui_models.py
@@ -56,7 +56,12 @@ class AudioMood(str, Enum):
 
 
 class ActionIntent(str, Enum):
-    """User action intents that trigger scene transitions"""
+    """User action intents that trigger scene transitions.
+
+    Canonical intents are shared by every client.  The legacy aliases remain
+    accepted during the cross-device rollout, but are normalized by the
+    WebSocket route before they reach the teaching engine.
+    """
     REQUEST_HINT = "request_hint"
     CONTINUE = "continue"
     RETRY = "retry"
@@ -64,6 +69,12 @@ class ActionIntent(str, Enum):
     ASK_QUESTION = "ask_question"
     REQUEST_EXAMPLE = "request_example"
     SKIP_AHEAD = "skip_ahead"
+
+    # Backward-compatible client aliases.
+    QUIZ_ANSWER = "quiz_answer"
+    USER_MESSAGE = "user_message"
+    CONFUSED = "confused"
+    TOO_EASY = "too_easy"
 
 
 class ValidationLevel(str, Enum):

--- a/lyo_app/ai_classroom/sdui_models.py
+++ b/lyo_app/ai_classroom/sdui_models.py
@@ -69,12 +69,32 @@ class ActionIntent(str, Enum):
     ASK_QUESTION = "ask_question"
     REQUEST_EXAMPLE = "request_example"
     SKIP_AHEAD = "skip_ahead"
+    SUBMIT_TRANSFER = "submit_transfer"
+    SET_MODE = "set_mode"
+    REQUEST_REVIEW = "request_review"
 
     # Backward-compatible client aliases.
     QUIZ_ANSWER = "quiz_answer"
     USER_MESSAGE = "user_message"
     CONFUSED = "confused"
     TOO_EASY = "too_easy"
+
+
+class ClassroomMode(str, Enum):
+    """Learner-controlled classroom format."""
+    SOLO = "solo"
+    CLASSROOM = "classroom"
+    CHALLENGE = "challenge"
+    REVIEW = "review"
+
+
+class HintLevel(str, Enum):
+    """Graduated help that preserves productive struggle."""
+    NUDGE = "nudge"
+    PRINCIPLE = "principle"
+    WORKED_STEP = "worked_step"
+    FULL_EXAMPLE = "full_example"
+    PREREQUISITE = "prerequisite"
 
 
 class ValidationLevel(str, Enum):
@@ -131,6 +151,11 @@ class TeacherMessage(ComponentBase):
     # Educational context
     concept_tags: List[str] = Field(default_factory=list, max_items=5)
     difficulty_level: Literal["beginner", "intermediate", "advanced"] = "beginner"
+    source_attributions: List[str] = Field(
+        default_factory=list,
+        max_items=5,
+        description="Course-provided provenance labels; never model-invented citations",
+    )
 
     @field_validator('text')
     @classmethod
@@ -251,17 +276,23 @@ class InputField(ComponentBase):
 
     type: Literal[ComponentType.INPUT_FIELD] = ComponentType.INPUT_FIELD
     placeholder: str = Field(..., max_length=100)
+    question: Optional[str] = Field(None, min_length=5, max_length=700)
+    action_intent: ActionIntent = ActionIntent.SUBMIT_TRANSFER
+    concept_id: Optional[str] = None
+    evidence_type: Literal["explanation", "application", "transfer", "retrieval"] = "transfer"
+    source_attributions: List[str] = Field(default_factory=list, max_items=5)
 
     # Input validation
     validation_level: ValidationLevel = ValidationLevel.LENIENT
     expected_keywords: List[str] = Field(default_factory=list, max_items=10)
-    min_words: int = Field(default=1, ge=1, le=100)
-    max_words: int = Field(default=50, ge=1, le=200)
+    min_words: int = Field(default=6, ge=1, le=100)
+    max_words: int = Field(default=120, ge=1, le=200)
+    min_score: float = Field(default=0.25, ge=0.0, le=1.0)
 
     # Input behavior
     auto_capitalize: bool = True
     spell_check: bool = True
-    multiline: bool = False
+    multiline: bool = True
 
 
 # ═══════════════════════════════════════════════════════════════════════════════════

--- a/lyo_app/ai_classroom/websocket_manager.py
+++ b/lyo_app/ai_classroom/websocket_manager.py
@@ -564,19 +564,27 @@ class WebSocketManager:
                 try:
                     payload = UserActionPayload(**message_data)
                 except Exception as parse_err:
-                    # Build minimal payload from just action_intent
-                    logger.warning(f"⚠️ Falling back to minimal UserActionPayload: {parse_err}")
-                    raw_intent = message_data.get("action_intent", "continue")
-                    try:
-                        intent = ActionIntent(raw_intent)
-                    except ValueError:
-                        intent = ActionIntent.CONTINUE
-                    payload = UserActionPayload(
-                        event_type=WebSocketEventType.USER_ACTION,
+                    # Never turn an invalid learner action into "continue".
+                    # That silently advanced lessons when clients sent a typo or
+                    # a not-yet-supported interaction, making the classroom look
+                    # adaptive while discarding the learner's intent.
+                    raw_intent = message_data.get("action_intent")
+                    logger.warning(
+                        "⚠️ Rejecting invalid classroom action %r: %s",
+                        raw_intent,
+                        parse_err,
+                    )
+                    error_payload = WebSocketPayload(
+                        event_type=WebSocketEventType.ERROR,
                         session_id=connection.session_id,
                         user_id=connection.user_id,
-                        action_intent=intent,
+                        data={
+                            "error": "unsupported_action",
+                            "action_intent": raw_intent,
+                        },
                     )
+                    await self.send_to_connection(connection_id, error_payload)
+                    return
                 await self._handle_user_action(payload, connection)
             else:
                 payload = WebSocketPayload(**message_data)

--- a/lyo_app/ai_classroom/websocket_routes.py
+++ b/lyo_app/ai_classroom/websocket_routes.py
@@ -34,6 +34,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/classroom/ws", tags=["AI Classroom WebSocket"])
 
 
+_ACTION_INTENT_ALIASES = {
+    ActionIntent.QUIZ_ANSWER: ActionIntent.SUBMIT_ANSWER,
+    ActionIntent.USER_MESSAGE: ActionIntent.ASK_QUESTION,
+    ActionIntent.CONFUSED: ActionIntent.REQUEST_HINT,
+    ActionIntent.TOO_EASY: ActionIntent.SKIP_AHEAD,
+}
+
+
+def canonical_action_intent(value: ActionIntent) -> ActionIntent:
+    """Return the single teaching-engine intent for any supported client alias."""
+    intent = value if isinstance(value, ActionIntent) else ActionIntent(value)
+    return _ACTION_INTENT_ALIASES.get(intent, intent)
+
+
 # ═══════════════════════════════════════════════════════════════════════════════════
 # 🔐 AUTHENTICATION FOR WEBSOCKETS
 # ═══════════════════════════════════════════════════════════════════════════════════
@@ -226,14 +240,40 @@ async def _register_lifecycle_handlers(
             # Get a fresh DB session dynamically to prevent connection pooling / leak issues over long-lived websockets
             async for db in get_async_session():
                 engine = SceneLifecycleEngine(db, ws_manager)
-                scene = await engine.handle_user_action(
-                    user_id=payload.user_id or connection.user_id,
-                    session_id=payload.session_id,
-                    action_intent=ActionIntent(payload.action_intent),
-                    action_data=payload.answer_data,
-                    component_id=payload.component_id
+                source_intent = ActionIntent(payload.action_intent)
+                action_intent = canonical_action_intent(source_intent)
+                action_data = dict(payload.answer_data or {})
+                action_data["source_intent"] = source_intent.value
+
+                if action_intent == ActionIntent.SUBMIT_ANSWER:
+                    selected_option_id = action_data.get("selected_option_id")
+                    if not selected_option_id:
+                        raise ValueError("Quiz submission requires selected_option_id")
+
+                    # The active server scene owns correctness.  Never trust a
+                    # client-supplied is_correct flag.
+                    scene = await engine.handle_quiz_submission(
+                        user_id=payload.user_id or connection.user_id,
+                        session_id=payload.session_id,
+                        quiz_component_id=payload.component_id or "",
+                        selected_option_id=str(selected_option_id),
+                        is_correct=False,
+                        response_time_ms=payload.response_time_ms or 0,
+                    )
+                else:
+                    scene = await engine.handle_user_action(
+                        user_id=payload.user_id or connection.user_id,
+                        session_id=payload.session_id,
+                        action_intent=action_intent,
+                        action_data=action_data,
+                        component_id=payload.component_id,
+                    )
+                logger.info(
+                    "🎯 User action processed dynamically: %s → %s → scene %s",
+                    source_intent.value,
+                    action_intent.value,
+                    scene.scene_id,
                 )
-                logger.info(f"🎯 User action processed dynamically: {payload.action_intent} → scene {scene.scene_id}")
                 break
 
         except Exception as e:

--- a/lyo_app/ai_classroom/websocket_routes.py
+++ b/lyo_app/ai_classroom/websocket_routes.py
@@ -11,6 +11,8 @@ Architecture: iOS Client ←→ WebSocket Routes ←→ Scene Lifecycle Engine �
 import asyncio
 import json
 import logging
+import os
+import secrets
 from typing import Optional, Dict, Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, Query, HTTPException
@@ -75,16 +77,17 @@ async def authenticate_websocket(
             logger.warning(f"WebSocket JWT authentication failed: {e}")
 
     if api_key:
-        # Allow guest access with API key
-        from lyo_app.models.enhanced import User
-        return User(
-            id="guest_session",
-            username="Guest Learner",
-            email="guest@lyo.app",
-            is_active=True
-        )
+        configured_key = os.getenv("CLASSROOM_GUEST_API_KEY")
+        if configured_key and secrets.compare_digest(api_key, configured_key):
+            from lyo_app.models.enhanced import User
+            return User(
+                id="guest_session",
+                username="Guest Learner",
+                email="guest@lyo.app",
+                is_active=True,
+            )
 
-    raise HTTPException(status_code=401, detail="Authentication required for WebSocket")
+    raise HTTPException(status_code=401, detail="Valid authentication required for WebSocket")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════════
@@ -118,20 +121,28 @@ async def websocket_endpoint(
         token = websocket.query_params.get("token")
         api_key = websocket.query_params.get("api_key")
 
-        # Basic authentication
+        # Authentication fails closed. Guest classrooms are available only
+        # when operators configure a dedicated secret.
         if not token and not api_key:
             await websocket.close(code=4001, reason="Authentication required")
             return
 
-        # For simplicity, we'll extract user_id from token or use guest
-        user_id = "guest_session"  # Default
         if token:
             try:
                 from lyo_app.auth.jwt_auth import verify_token_async
                 token_data = await verify_token_async(token, expected_type="access")
-                user_id = str(token_data.user_id) if token_data.user_id else "guest_session"
-            except:
-                user_id = "guest_session"
+                if not token_data.user_id:
+                    raise ValueError("Token has no user id")
+                user_id = str(token_data.user_id)
+            except Exception:
+                await websocket.close(code=4001, reason="Invalid authentication token")
+                return
+        else:
+            configured_key = os.getenv("CLASSROOM_GUEST_API_KEY")
+            if not configured_key or not secrets.compare_digest(api_key or "", configured_key):
+                await websocket.close(code=4001, reason="Guest classroom is not configured")
+                return
+            user_id = f"guest_{session_id}"
 
         # Connect client
         connection = await ws_manager.connect_client(
@@ -249,14 +260,23 @@ async def _register_lifecycle_handlers(
                     if not selected_option_id:
                         raise ValueError("Quiz submission requires selected_option_id")
 
-                    # The active server scene owns correctness.  Never trust a
-                    # client-supplied is_correct flag.
+                    # The active server scene owns correctness.
                     scene = await engine.handle_quiz_submission(
                         user_id=payload.user_id or connection.user_id,
                         session_id=payload.session_id,
                         quiz_component_id=payload.component_id or "",
                         selected_option_id=str(selected_option_id),
-                        is_correct=False,
+                        response_time_ms=payload.response_time_ms or 0,
+                    )
+                elif action_intent == ActionIntent.SUBMIT_TRANSFER:
+                    response = str(action_data.get("response") or "").strip()
+                    if not response:
+                        raise ValueError("Transfer submission requires a response")
+                    scene = await engine.handle_transfer_submission(
+                        user_id=payload.user_id or connection.user_id,
+                        session_id=payload.session_id,
+                        input_component_id=payload.component_id or "",
+                        response=response,
                         response_time_ms=payload.response_time_ms or 0,
                     )
                 else:
@@ -326,6 +346,11 @@ async def _send_welcome_scene(
         topic_from_query = connection.websocket.query_params.get("topic")
         objective_from_query = connection.websocket.query_params.get("objective")
         difficulty_from_query = connection.websocket.query_params.get("difficulty")
+        mode_from_query = connection.websocket.query_params.get("mode") or "solo"
+        duration_from_query = connection.websocket.query_params.get("duration_minutes") or "10"
+        reduced_motion_from_query = (
+            connection.websocket.query_params.get("reduced_motion") or "false"
+        ).lower() == "true"
 
         # Resolve topic from the ConversationManager session (if one exists)
         # Also ensure a ConversationSession exists for lesson tracking
@@ -371,6 +396,9 @@ async def _send_welcome_scene(
                 "topic": resolved_topic,
                 "objective": objective_from_query,
                 "difficulty": difficulty_from_query,
+                "mode": mode_from_query,
+                "duration_minutes": duration_from_query,
+                "reduced_motion": reduced_motion_from_query,
             },
             urgency=1
         )
@@ -532,22 +560,18 @@ async def submit_quiz_answer(
         # Initialize lifecycle engine
         lifecycle_engine = SceneLifecycleEngine(db, ws_manager)
 
-        # TODO: Determine if answer is correct (would query quiz data)
-        is_correct = selected_option_id == "b"  # Mock logic
-
-        # Process quiz submission
+        # The active QuizCard retained by the lifecycle engine is authoritative.
         scene = await lifecycle_engine.handle_quiz_submission(
             user_id=str(current_user.id),
             session_id=session_id,
             quiz_component_id=quiz_component_id,
             selected_option_id=selected_option_id,
-            is_correct=is_correct,
-            response_time_ms=response_time_ms
+            response_time_ms=response_time_ms,
         )
 
         return {
             "success": True,
-            "is_correct": is_correct,
+            "validated_by_server": True,
             "scene_id": scene.scene_id,
             "scene_type": scene.scene_type,
             "feedback_components": len([c for c in scene.components if c.type in ["TeacherMessage", "Celebration"]]),

--- a/lyo_app/ai_classroom/websocket_routes.py
+++ b/lyo_app/ai_classroom/websocket_routes.py
@@ -36,7 +36,6 @@ router = APIRouter(prefix="/api/v1/classroom/ws", tags=["AI Classroom WebSocket"
 
 _ACTION_INTENT_ALIASES = {
     ActionIntent.QUIZ_ANSWER: ActionIntent.SUBMIT_ANSWER,
-    ActionIntent.USER_MESSAGE: ActionIntent.ASK_QUESTION,
     ActionIntent.CONFUSED: ActionIntent.REQUEST_HINT,
     ActionIntent.TOO_EASY: ActionIntent.SKIP_AHEAD,
 }

--- a/lyo_app/ai_classroom/websocket_routes.py
+++ b/lyo_app/ai_classroom/websocket_routes.py
@@ -321,8 +321,12 @@ async def _send_welcome_scene(
         return
 
     try:
-        # Topic passed explicitly by iOS client (courseTitle from the course proposal)
+        # Explicit course context comes from the generated course card. Keep it
+        # attached to the session so instruction is driven by a goal, not only
+        # a display title.
         topic_from_query = connection.websocket.query_params.get("topic")
+        objective_from_query = connection.websocket.query_params.get("objective")
+        difficulty_from_query = connection.websocket.query_params.get("difficulty")
 
         # Resolve topic from the ConversationManager session (if one exists)
         # Also ensure a ConversationSession exists for lesson tracking
@@ -363,7 +367,12 @@ async def _send_welcome_scene(
             user_id=connection.user_id,
             session_id=connection.session_id,
             course_id=course_id,
-            action_data={"welcome": True, "topic": resolved_topic},
+            action_data={
+                "welcome": True,
+                "topic": resolved_topic,
+                "objective": objective_from_query,
+                "difficulty": difficulty_from_query,
+            },
             urgency=1
         )
 

--- a/lyo_app/personalization/service.py
+++ b/lyo_app/personalization/service.py
@@ -413,15 +413,20 @@ class PersonalizationEngine:
         """
         Update knowledge tracking from assessment
         """
+        # Schemas accept IDs from JSON as strings; database foreign keys are
+        # integers. Normalize once so mastery and review scheduling share the
+        # same learner record on PostgreSQL.
+        learner_id = int(request.learner_id)
+
         # Capture prior mastery so clients can award honest, delta-based XP.
         old_mastery, _ = await self.dkt.get_skill_readiness(
-            db, request.learner_id, request.skill_id
+            db, learner_id, request.skill_id
         )
 
         # Update mastery
         new_mastery = await self.dkt.update_mastery(
             db,
-            request.learner_id,
+            learner_id,
             request.skill_id,
             request.correct,
             request.time_taken_seconds,
@@ -431,7 +436,7 @@ class PersonalizationEngine:
         # Update spaced repetition schedule
         await self._update_repetition_schedule(
             db,
-            request.learner_id,
+            learner_id,
             request.skill_id,
             request.item_id,
             request.correct

--- a/tests/test_ai_classroom_teaching_loop.py
+++ b/tests/test_ai_classroom_teaching_loop.py
@@ -1,0 +1,106 @@
+"""Contract tests for the guided AI Classroom teaching loop."""
+
+import unittest
+
+from lyo_app.ai_classroom.sdui_models import ActionIntent, SceneType
+from lyo_app.ai_classroom.scene_lifecycle_engine import (
+    ClassroomDirector,
+    ContextSnapshot,
+    Trigger,
+    TriggerType,
+)
+from lyo_app.ai_classroom.websocket_routes import canonical_action_intent
+
+
+class ClassroomActionContractTests(unittest.TestCase):
+    def test_legacy_clients_map_to_canonical_teaching_actions(self):
+        self.assertEqual(
+            canonical_action_intent(ActionIntent.QUIZ_ANSWER),
+            ActionIntent.SUBMIT_ANSWER,
+        )
+        self.assertEqual(
+            canonical_action_intent(ActionIntent.CONFUSED),
+            ActionIntent.REQUEST_HINT,
+        )
+        self.assertEqual(
+            canonical_action_intent(ActionIntent.TOO_EASY),
+            ActionIntent.SKIP_AHEAD,
+        )
+
+    def test_learner_response_is_not_misclassified_as_a_question(self):
+        self.assertEqual(
+            canonical_action_intent(ActionIntent.USER_MESSAGE),
+            ActionIntent.USER_MESSAGE,
+        )
+
+
+class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.director = ClassroomDirector()
+        self.context = ContextSnapshot(
+            user_id="42",
+            session_id="course-1",
+            topic="Fractions",
+            learning_objective="Compare fractions with unlike denominators",
+        )
+
+    def trigger(self, action_intent, **action_data):
+        return Trigger(
+            trigger_type=TriggerType.USER_ACTION,
+            user_id="42",
+            session_id="course-1",
+            action_data={"action_intent": action_intent, **action_data},
+        )
+
+    async def test_continue_checks_understanding_before_advancing(self):
+        decision = await self.director.decide_scene(
+            self.trigger(ActionIntent.CONTINUE),
+            self.context,
+        )
+        self.assertEqual(decision.selected_scene_type, SceneType.CHALLENGE)
+        self.assertTrue(decision.require_interaction)
+
+    async def test_mastered_checkpoint_advances_to_instruction(self):
+        decision = await self.director.decide_scene(
+            self.trigger(ActionIntent.CONTINUE, advanced_after_mastery=True),
+            self.context,
+        )
+        self.assertEqual(decision.selected_scene_type, SceneType.INSTRUCTION)
+
+    async def test_correct_checkpoint_is_confirmed_before_advancing(self):
+        decision = await self.director.decide_scene(
+            self.trigger(
+                ActionIntent.SUBMIT_ANSWER,
+                answer_data={"is_correct": True},
+            ),
+            self.context,
+        )
+        self.assertEqual(decision.selected_scene_type, SceneType.CELEBRATION)
+
+    async def test_incorrect_checkpoint_reteaches(self):
+        decision = await self.director.decide_scene(
+            self.trigger(
+                ActionIntent.SUBMIT_ANSWER,
+                answer_data={"is_correct": False},
+            ),
+            self.context,
+        )
+        self.assertEqual(decision.selected_scene_type, SceneType.CORRECTION)
+
+    async def test_adaptive_signals_change_the_pedagogical_move(self):
+        hint = await self.director.decide_scene(
+            self.trigger(ActionIntent.REQUEST_HINT),
+            self.context,
+        )
+        stretch = await self.director.decide_scene(
+            self.trigger(ActionIntent.SKIP_AHEAD),
+            self.context,
+        )
+        self.assertEqual(hint.selected_scene_type, SceneType.INSTRUCTION)
+        self.assertLess(hint.difficulty_adjustment, 0)
+        self.assertEqual(stretch.selected_scene_type, SceneType.INSTRUCTION)
+        self.assertGreater(stretch.difficulty_adjustment, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai_classroom_teaching_loop.py
+++ b/tests/test_ai_classroom_teaching_loop.py
@@ -1,6 +1,7 @@
 """Contract tests for the evidence-based AI Classroom teaching loop."""
 
 import unittest
+from unittest.mock import AsyncMock
 
 from lyo_app.ai_classroom.sdui_models import (
     ActionIntent,
@@ -18,6 +19,8 @@ from lyo_app.ai_classroom.scene_lifecycle_engine import (
     score_transfer_response,
 )
 from lyo_app.ai_classroom.websocket_routes import canonical_action_intent
+from lyo_app.personalization.schemas import KnowledgeTraceRequest
+from lyo_app.personalization.service import PersonalizationEngine
 
 
 class ClassroomActionContractTests(unittest.TestCase):
@@ -87,6 +90,28 @@ class TransferEvidenceTests(unittest.TestCase):
         )
         self.assertIn("fractions", keywords)
         self.assertIn("denominators", keywords)
+
+
+class SpacedRetrievalContractTests(unittest.IsolatedAsyncioTestCase):
+    async def test_trace_normalizes_json_user_id_for_mastery_and_schedule(self):
+        engine = PersonalizationEngine()
+        engine.dkt.get_skill_readiness = AsyncMock(return_value=(0.2, 0.8))
+        engine.dkt.update_mastery = AsyncMock(return_value=0.4)
+        engine._update_repetition_schedule = AsyncMock()
+        db = object()
+        await engine.trace_knowledge(
+            db,
+            KnowledgeTraceRequest(
+                learner_id="42",
+                skill_id="fractions",
+                item_id="compare fractions",
+                correct=True,
+                time_taken_seconds=8,
+            ),
+        )
+        engine.dkt.update_mastery.assert_awaited_once()
+        self.assertEqual(engine.dkt.update_mastery.await_args.args[1], 42)
+        self.assertEqual(engine._update_repetition_schedule.await_args.args[1], 42)
 
 
 class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_ai_classroom_teaching_loop.py
+++ b/tests/test_ai_classroom_teaching_loop.py
@@ -1,13 +1,21 @@
-"""Contract tests for the guided AI Classroom teaching loop."""
+"""Contract tests for the evidence-based AI Classroom teaching loop."""
 
 import unittest
 
-from lyo_app.ai_classroom.sdui_models import ActionIntent, SceneType
+from lyo_app.ai_classroom.sdui_models import (
+    ActionIntent,
+    ClassroomMode,
+    HintLevel,
+    InputField,
+    SceneType,
+)
 from lyo_app.ai_classroom.scene_lifecycle_engine import (
     ClassroomDirector,
     ContextSnapshot,
     Trigger,
     TriggerType,
+    expected_transfer_keywords,
+    score_transfer_response,
 )
 from lyo_app.ai_classroom.websocket_routes import canonical_action_intent
 
@@ -27,11 +35,58 @@ class ClassroomActionContractTests(unittest.TestCase):
             ActionIntent.SKIP_AHEAD,
         )
 
-    def test_learner_response_is_not_misclassified_as_a_question(self):
+    def test_new_evidence_and_mode_intents_are_canonical(self):
         self.assertEqual(
-            canonical_action_intent(ActionIntent.USER_MESSAGE),
-            ActionIntent.USER_MESSAGE,
+            canonical_action_intent(ActionIntent.SUBMIT_TRANSFER),
+            ActionIntent.SUBMIT_TRANSFER,
         )
+        self.assertEqual(
+            canonical_action_intent(ActionIntent.SET_MODE),
+            ActionIntent.SET_MODE,
+        )
+
+    def test_transfer_input_carries_a_transparent_server_rubric(self):
+        field = InputField(
+            question="Apply proportional reasoning to a new recipe.",
+            placeholder="Explain your example",
+            concept_id="proportional reasoning",
+            expected_keywords=["ratio", "scale"],
+        )
+        self.assertEqual(field.action_intent, ActionIntent.SUBMIT_TRANSFER.value)
+        self.assertEqual(field.evidence_type, "transfer")
+        self.assertGreater(field.min_words, 1)
+
+
+class TransferEvidenceTests(unittest.TestCase):
+    def test_substantive_application_with_rubric_language_passes(self):
+        correct, coverage, missing = score_transfer_response(
+            "I use the ratio to scale every ingredient by the same factor.",
+            ["ratio", "scale", "factor"],
+            min_words=6,
+            min_score=0.25,
+        )
+        self.assertTrue(correct)
+        self.assertGreaterEqual(coverage, 2 / 3)
+        self.assertEqual(missing, ["factor"] if coverage < 1 else [])
+
+    def test_short_or_unrelated_response_fails(self):
+        correct, coverage, missing = score_transfer_response(
+            "I get it.",
+            ["ratio", "scale"],
+            min_words=6,
+            min_score=0.25,
+        )
+        self.assertFalse(correct)
+        self.assertEqual(coverage, 0)
+        self.assertEqual(missing, ["ratio", "scale"])
+
+    def test_keywords_come_from_authored_objective_and_content(self):
+        keywords = expected_transfer_keywords(
+            "Compare fractions with unlike denominators",
+            "Use a common denominator before comparing numerators.",
+        )
+        self.assertIn("fractions", keywords)
+        self.assertIn("denominators", keywords)
 
 
 class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):
@@ -67,7 +122,7 @@ class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(decision.selected_scene_type, SceneType.INSTRUCTION)
 
-    async def test_correct_checkpoint_is_confirmed_before_advancing(self):
+    async def test_correct_recognition_requires_transfer_evidence(self):
         decision = await self.director.decide_scene(
             self.trigger(
                 ActionIntent.SUBMIT_ANSWER,
@@ -75,19 +130,40 @@ class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):
             ),
             self.context,
         )
+        self.assertEqual(decision.selected_scene_type, SceneType.REFLECTION)
+        self.assertTrue(decision.require_interaction)
+
+    async def test_correct_transfer_confirms_mastery(self):
+        decision = await self.director.decide_scene(
+            self.trigger(
+                ActionIntent.SUBMIT_TRANSFER,
+                answer_data={"is_correct": True},
+            ),
+            self.context,
+        )
         self.assertEqual(decision.selected_scene_type, SceneType.CELEBRATION)
 
-    async def test_incorrect_checkpoint_reteaches(self):
-        decision = await self.director.decide_scene(
+    async def test_incorrect_evidence_reteaches(self):
+        recognition = await self.director.decide_scene(
             self.trigger(
                 ActionIntent.SUBMIT_ANSWER,
                 answer_data={"is_correct": False},
             ),
             self.context,
         )
-        self.assertEqual(decision.selected_scene_type, SceneType.CORRECTION)
+        transfer = await self.director.decide_scene(
+            self.trigger(
+                ActionIntent.SUBMIT_TRANSFER,
+                answer_data={"is_correct": False},
+            ),
+            self.context,
+        )
+        self.assertEqual(recognition.selected_scene_type, SceneType.CORRECTION)
+        self.assertEqual(transfer.selected_scene_type, SceneType.CORRECTION)
+        self.assertTrue(transfer.require_interaction)
 
-    async def test_adaptive_signals_change_the_pedagogical_move(self):
+    async def test_hint_ladder_and_challenge_mode_change_the_move(self):
+        self.context.hint_level = HintLevel.NUDGE
         hint = await self.director.decide_scene(
             self.trigger(ActionIntent.REQUEST_HINT),
             self.context,
@@ -98,8 +174,20 @@ class ClassroomDirectorTeachingLoopTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(hint.selected_scene_type, SceneType.INSTRUCTION)
         self.assertLess(hint.difficulty_adjustment, 0)
-        self.assertEqual(stretch.selected_scene_type, SceneType.INSTRUCTION)
         self.assertGreater(stretch.difficulty_adjustment, 0)
+
+    async def test_review_mode_opens_with_due_retrieval(self):
+        self.context.classroom_mode = ClassroomMode.REVIEW
+        self.context.review_due_items = ["fraction comparison"]
+        decision = await self.director.decide_scene(
+            Trigger(
+                trigger_type=TriggerType.SYSTEM_TIMEOUT,
+                user_id="42",
+                session_id="course-1",
+            ),
+            self.context,
+        )
+        self.assertEqual(decision.selected_scene_type, SceneType.CHALLENGE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rebuilds the live AI Classroom around evidence-based guided mastery instead of interaction theater.

- makes the Teacher the default lead; AI classmates are optional and Solo Teacher is the default mode
- follows teach → recognition check → explanation/application → targeted remediation → mastery → advance
- requires both recognition and transfer evidence before a lesson becomes mastered
- generates misconception-specific distractors, feedback, and remediation cues
- adds a five-level hint ladder: nudge, principle, first step, worked example, prerequisite
- schedules spaced retrieval through the canonical personalization service and adds Review mode
- adds Solo, Classroom, Challenge, and Review modes plus learner-selected session targets
- closes lessons with a concrete evidence summary and scheduled retrieval cue
- carries course provenance into scenes and prohibits invented citations/observations
- makes visuals objective-driven; manipulables require a prediction/explanation prompt
- persists mode, evidence, hint counts, misconception history, and lesson position
- fails WebSocket authentication closed and validates every quiz/transfer response against the active server scene

## Verification

- Backend CI passed completely: PostgreSQL migrations, full tests with coverage, fatal-error audit, lint report, high-confidence security scan, and type-debt report
- changed Python modules pass `py_compile`
- focused tests cover action aliases, the evidence gate, deterministic transfer scoring, hint behavior, review mode, and canonical spaced-retrieval learner IDs

Coordinated web-client changes: [Lyo_Da_One PR #9](https://github.com/Hectorg0827/Lyo_Da_One/pull/9).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to live classroom flow, WebSocket auth, and lesson progression; incorrect gating or persistence could block learners or advance lessons without mastery.
> 
> **Overview**
> Replaces theater-first classroom scripting with an **evidence-based mastery loop**: teach → recognition quiz → open transfer → remediation → celebration, with lesson advance only after both recognition and transfer pass.
> 
> **Director prompt** now prioritizes clear teaching and objective-driven checks; classmates are optional (no mistake quota); adaptation uses only server-supplied signals (`learning_objective`, `learner_context`, misconception/remediation metadata); and scenes align with **solo / classroom / challenge / review** modes.
> 
> **Scene lifecycle** gains richer `ContextSnapshot` (mode, duration, hints, learner messages), hydration/persistence via `ClassroomSession.context`, mastery from `LearnerMastery` + personalization traces, deterministic **transfer rubric** scoring (`expected_transfer_keywords` / `score_transfer_response`), graduated hints, misconception-aware quiz options, `REFLECTION` transfer `InputField`s, and a progress bar tied to mastered lessons—not tap-to-advance.
> 
> **WebSocket/HTTP** routes canonicalize legacy action aliases, reject invalid actions instead of defaulting to `continue`, validate quiz/transfer against the active scene, add `handle_transfer_submission`, tighten guest auth (`CLASSROOM_GUEST_API_KEY`), and pass welcome query params (objective, mode, duration).
> 
> **Personalization** normalizes string learner IDs in `trace_knowledge`. New contract tests cover the teaching loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451d3143987012571b98eb858d3b4d7aff192315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->