### PR TITLE
Fix backend release image scan

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Scan container
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ needs.build.outputs.image-ref }}
           format: sarif


### PR DESCRIPTION
## What changed

- updates `aquasecurity/trivy-action` from the unavailable `0.28.0` tag to the current `v0.36.0` release

## Why

The post-merge main workflow passed migrations, the full test suite, audits, and multi-platform image publication, but the security job failed during runner setup because GitHub could no longer resolve `0.28.0`.

## Validation

- confirmed `v0.36.0` is the latest published Trivy Action release
- workflow YAML lint passes
- change is limited to the action version pin

## Summary by Sourcery

CI:
- Bump aquasecurity/trivy-action in the production deployment workflow from 0.28.0 to v0.36.0 to restore the image security scan job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin with no application or deployment logic changes; scan behavior stays the same aside from using a current Trivy Action release.
> 
> **Overview**
> Restores the **Scan immutable release image** job on `main` by repinning `aquasecurity/trivy-action` from the unresolvable `0.28.0` reference to **`v0.36.0`**.
> 
> Scan inputs (digest-based `image-ref`, SARIF output, HIGH/CRITICAL severity, `exit-code: '1'`) are unchanged—only the action version pin is updated so the security step can run again after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b606f3c4a970a43a11e2beb3798da1fcf25a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->