### PR TITLE
Fix production dependency vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ influxdb-client==1.40.0
 # Authentication & Security
 passlib[bcrypt]==1.7.4
 bcrypt==3.2.2
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 bleach==6.1.0
 python-decouple==3.8
 argon2-cffi==23.1.0
@@ -46,8 +46,8 @@ email-validator==2.1.0
 aiosmtplib==3.0.1
 
 # File Upload & Media Processing
-python-multipart==0.0.6
-pillow==10.1.0
+python-multipart==0.0.30
+pillow==10.3.0
 opencv-python-headless==4.8.1.78
 imageio==2.34.0
 moviepy==1.0.3
@@ -75,9 +75,9 @@ google-generativeai>=0.7.2
 openai>=1.35.0
 anthropic>=0.39.0
 google-cloud-secret-manager==2.20.2
-google-cloud-firestore==2.16.0
+google-cloud-firestore==2.18.0
 google-cloud-storage==2.17.0
-google-cloud-aiplatform>=1.50.0
+google-cloud-aiplatform==1.133.0
 firebase-admin==6.5.0
 google-cloud-texttospeech>=2.16.0
 runwayml>=4.6.0
@@ -86,19 +86,23 @@ tavily-python>=0.3.0
 resend>=0.8.0
 
 # Features & Utils
-websockets==12.0
+websockets==13.1
 scikit-learn==1.3.2
 numpy==1.26.2
 pandas==2.1.4
-orjson==3.9.10
+orjson==3.11.6
 lz4==4.3.2
 elasticsearch==8.11.1
 rollbar==0.16.3
 beautifulsoup4==4.12.2
-lxml==4.9.3
+lxml==6.1.0
 python-dateutil==2.8.2
 psutil==5.9.6
 py-cpuinfo==9.0.0
 
 # Production Server Option
-gunicorn==21.2.0
+gunicorn==22.0.0
+
+# Keep the generated Google/Vertex stack on a security-fixed protobuf 5.x.
+# This remains inside google-cloud-aiplatform's supported runtime range (<7).
+protobuf==5.29.6


### PR DESCRIPTION
## What changed

Updates the eight vulnerable runtime packages reported by the main-branch Trivy scan:

- Pillow `10.1.0` → `10.3.0`
- google-cloud-aiplatform `>=1.50.0` → `1.133.0`
- gunicorn `21.2.0` → `22.0.0`
- lxml `4.9.3` → `6.1.0`
- orjson `3.9.10` → `3.11.6`
- python-jose `3.3.0` → `3.4.0`
- python-multipart `0.0.6` → `0.0.30`
- protobuf (transitive `4.25.9`) → explicit `5.29.6`

Compatibility companions:

- google-cloud-firestore `2.16.0` → `2.18.0` so protobuf 5 is supported
- websockets `12.0` → `13.1` for google-cloud-aiplatform's google-genai dependency

## Why

The production image scan reported 15 fixable high/critical findings across these packages, including Pillow arbitrary code execution, python-jose algorithm confusion, multipart traversal/DoS issues, request smuggling, XML local-file disclosure, and JSON/protobuf DoS issues.

## Validation

- every selected release exists on PyPI and supports the production Python runtimes
- full `pip` dependency resolution succeeds on Python 3.12
- the pinned protobuf 5 release stays within google-cloud-aiplatform's supported `<7` range
- the normal CI migration, full test, audit, production image, and Trivy gates will validate the integrated upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth (python-jose), file uploads (multipart), the production WSGI server (gunicorn), and the Google/Vertex/protobuf stack; risk is mitigated by version-only changes and stated pip/CI validation, but runtime regressions remain possible across JWT, uploads, and Vertex/Firestore.
> 
> **Overview**
> **Bumps pinned runtime dependencies in `requirements.txt`** to address Trivy-reported high/critical issues—no application code changes.
> 
> Security-focused upgrades include **Pillow**, **python-jose**, **python-multipart**, **gunicorn**, **lxml**, **orjson**, and a pinned **google-cloud-aiplatform** (`1.133.0`, replacing a loose `>=1.50.0`). **protobuf** is now explicitly pinned to **`5.29.6`** (replacing a vulnerable transitive 4.x), with **google-cloud-firestore** raised for protobuf 5 compatibility and **websockets** bumped for the aiplatform / google-genai stack.
> 
> Comments in the file document why protobuf 5.x is pinned and that it stays within aiplatform’s supported `<7` range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e5f1469bdf9d9d81acfd47ae72dd3bcc11a5a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->