### PR TITLE
Finish production dependency remediation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,13 +20,14 @@ influxdb-client==1.40.0
 # Authentication & Security
 passlib[bcrypt]==1.7.4
 bcrypt==3.2.2
-python-jose[cryptography]==3.4.0
+python-jose[cryptography]==3.5.0
 bleach==6.1.0
 python-decouple==3.8
 argon2-cffi==23.1.0
 cryptography>=41.0.0
 pyotp==2.9.0
 qrcode==7.4.2
+pyasn1==0.6.3
 
 # Caching & Background Jobs
 redis[hiredis]==5.0.1
@@ -47,7 +48,7 @@ aiosmtplib==3.0.1
 
 # File Upload & Media Processing
 python-multipart==0.0.30
-pillow==10.3.0
+pillow==12.2.0
 opencv-python-headless==4.8.1.78
 imageio==2.34.0
 moviepy==1.0.3


### PR DESCRIPTION
## What changed

- Pillow `10.3.0` → `12.2.0`
- pyasn1 (transitive `0.4.8`) → explicit `0.6.3`
- python-jose `3.4.0` → `3.5.0` so the fixed pyasn1 release is supported

## Why

A direct scan of the upgraded immutable image found the four remaining high findings: three newer 2026 Pillow issues (PSD out-of-bounds write/arbitrary code execution and FITS decompression DoS) plus pyasn1 unbounded-recursion DoS.

## Validation

- selected releases exist on PyPI and support Python 3.11/3.12
- full dependency resolution succeeds
- python-jose 3.5.0 supports pyasn1 >=0.5.0
- normal migration/full-test/image/Trivy gates will validate the integrated result

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major Pillow upgrade and auth-stack pins can affect image handling and JWT/crypto paths; scope is limited to version pins with stated resolution and compatibility checks.
> 
> **Overview**
> **Production dependency remediation** to clear remaining high-severity scan findings on the backend image.
> 
> **Pillow** is bumped from `10.3.0` to `12.2.0` to address PSD/FITS-related vulnerabilities in image processing. **python-jose** moves from `3.4.0` to `3.5.0`, and **pyasn1** is pinned explicitly at `0.6.3` (replacing an older transitive `0.4.8`) to fix unbounded-recursion DoS and align with jose’s supported pyasn1 range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48663051b2394c9aaeba8703c2c5a55c6fdd06cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->