### PR TITLE
Fix Trivy SARIF severity gate

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -176,6 +176,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: HIGH,CRITICAL
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           exit-code: '1'
 


### PR DESCRIPTION
## What changed

- sets `limit-severities-for-sarif: true` on the production image scan

## Why

Trivy Action's documented SARIF default emits all severities regardless of the configured `severity` input. With `exit-code: 1`, that made the HIGH/CRITICAL gate fail on lower-severity findings even though a direct scan of the published digest returned zero HIGH/CRITICAL vulnerabilities.

This preserves SARIF upload and keeps the build blocking on exactly the declared HIGH/CRITICAL threshold; it does not add ignores or suppress identified high-risk issues.

## Validation

- official Trivy Action v0.36.0 documentation confirms this input is required to apply the configured severities to SARIF
- direct scan of `sha256:001fa011...` returns zero HIGH/CRITICAL fixable findings
- workflow YAML remains valid

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow input change; tightens scan gating to match documented severity behavior with no application or security logic changes.
> 
> **Overview**
> The production image **Trivy SARIF** step now sets **`limit-severities-for-sarif: true`** so the scan honors the existing `severity: HIGH,CRITICAL` setting.
> 
> Without this, Trivy Action still emits lower-severity findings in SARIF while **`exit-code: '1'`** fails the job on any reported issue—so builds could block on MEDIUM/LOW findings even when there are no HIGH/CRITICAL vulnerabilities. SARIF upload and the intended HIGH/CRITICAL gate behavior are unchanged aside from aligning exit behavior with that threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55b52a14f9f7739b5bd3727ad4fbf21302ad19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->