### PR TITLE
Make the clips (reels) API fully operational

### DIFF
--- a/alembic/versions/clips_sync_001_add_comments_and_count.py
+++ b/alembic/versions/clips_sync_001_add_comments_and_count.py
@@ -1,0 +1,51 @@
+"""Add clip_comments table and clips.comment_count.
+
+Clients render a comment button and count on every reel, but no comments
+API or storage existed for clips. Adds the denormalized-author comments
+table (matching community post comments) and a comment_count column.
+
+Revision ID: clips_sync_001
+Revises: community_sync_001
+Create Date: 2026-07-20
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "clips_sync_001"
+down_revision = "community_sync_001"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name: str) -> bool:
+    bind = op.get_bind()
+    return sa.inspect(bind).has_table(name)
+
+
+def _existing_columns(table: str) -> set:
+    bind = op.get_bind()
+    return {c["name"] for c in sa.inspect(bind).get_columns(table)}
+
+
+def upgrade() -> None:
+    if _has_table("clips") and "comment_count" not in _existing_columns("clips"):
+        op.add_column("clips", sa.Column("comment_count", sa.Integer(), nullable=False, server_default="0"))
+
+    if not _has_table("clip_comments"):
+        op.create_table(
+            "clip_comments",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("clip_id", sa.Integer(), sa.ForeignKey("clips.id"), nullable=False, index=True),
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False, index=True),
+            sa.Column("author_name", sa.String(length=150), nullable=False, server_default=""),
+            sa.Column("author_avatar", sa.String(length=500), nullable=True),
+            sa.Column("content", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("clip_comments"):
+        op.drop_table("clip_comments")
+    if _has_table("clips") and "comment_count" in _existing_columns("clips"):
+        op.drop_column("clips", "comment_count")

--- a/lyo_app/community/routes.py
+++ b/lyo_app/community/routes.py
@@ -61,6 +61,7 @@ async def list_study_groups(
     limit: int = Query(20, ge=1, le=100),
     privacy: Optional[StudyGroupPrivacy] = Query(None),
     course_id: Optional[int] = Query(None),
+    q: Optional[str] = Query(None, max_length=200, description="Text search over name/description"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
@@ -72,7 +73,8 @@ async def list_study_groups(
             limit=limit,
             privacy=privacy,
             course_id=course_id,
-            user_id=current_user.id
+            user_id=current_user.id,
+            q=q,
         )
         return study_groups
     except Exception as e:
@@ -300,6 +302,7 @@ async def list_community_events(
     event_type: Optional[EventType] = Query(None),
     study_group_id: Optional[int] = Query(None),
     upcoming_only: bool = Query(True),
+    q: Optional[str] = Query(None, max_length=200, description="Text search over title/description/location"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
@@ -312,7 +315,8 @@ async def list_community_events(
             event_type=event_type,
             study_group_id=study_group_id,
             upcoming_only=upcoming_only,
-            user_id=current_user.id
+            user_id=current_user.id,
+            q=q,
         )
         
         # response_model is List[CommunityEventRead]; the previous dict

--- a/lyo_app/community/service.py
+++ b/lyo_app/community/service.py
@@ -365,6 +365,7 @@ class CommunityService:
         course_id: Optional[int] = None,
         privacy: Optional[StudyGroupPrivacy] = None,
         status: Optional[StudyGroupStatus] = StudyGroupStatus.ACTIVE,
+        q: Optional[str] = None,
         skip: int = 0, 
         limit: int = 20
     ) -> List[Dict[str, Any]]:
@@ -397,6 +398,12 @@ class CommunityService:
             # Only show public groups by default unless user is specified
             if not user_id:
                 conditions.append(StudyGroup.privacy == StudyGroupPrivacy.PUBLIC)
+        if q:
+            pattern = f"%{q.strip()}%"
+            conditions.append(or_(
+                StudyGroup.name.ilike(pattern),
+                StudyGroup.description.ilike(pattern),
+            ))
         
         if conditions:
             query = query.where(and_(*conditions))
@@ -925,6 +932,7 @@ class CommunityService:
         event_type: Optional[str] = None,
         status: Optional[EventStatus] = None,
         upcoming_only: bool = False,
+        q: Optional[str] = None,
         skip: int = 0, 
         limit: int = 20
     ) -> List[Dict[str, Any]]:
@@ -959,6 +967,13 @@ class CommunityService:
             conditions.append(CommunityEvent.event_type == event_type)
         if upcoming_only:
             conditions.append(CommunityEvent.start_time > datetime.utcnow())
+        if q:
+            pattern = f"%{q.strip()}%"
+            conditions.append(or_(
+                CommunityEvent.title.ilike(pattern),
+                CommunityEvent.description.ilike(pattern),
+                CommunityEvent.location.ilike(pattern),
+            ))
         
         if conditions:
             query = query.where(and_(*conditions))

--- a/lyo_app/enhanced_main.py
+++ b/lyo_app/enhanced_main.py
@@ -516,6 +516,14 @@ def create_app() -> FastAPI:
     except ImportError as e:
         logger.warning(f"Clips routes not available: {e}")
     
+    # User media Router - multipart upload + public serving for reels/posts
+    try:
+        from lyo_app.routers.user_media import router as user_media_router
+        app.include_router(user_media_router)
+        logger.info("✅ User media routes integrated - reel/post uploads active!")
+    except ImportError as e:
+        logger.warning(f"User media routes not available: {e}")
+
     # Messaging Router - Direct messages between users
     try:
         from lyo_app.routers.messaging import router as messaging_router

--- a/lyo_app/enhanced_main.py
+++ b/lyo_app/enhanced_main.py
@@ -516,6 +516,14 @@ def create_app() -> FastAPI:
     except ImportError as e:
         logger.warning(f"Clips routes not available: {e}")
     
+    # Search Router - cross-entity search (users, groups, events, posts)
+    try:
+        from lyo_app.routers.search import router as search_router
+        app.include_router(search_router, prefix="/api/v1")
+        logger.info("✅ Search routes integrated - cross-entity search active!")
+    except ImportError as e:
+        logger.warning(f"Search routes not available: {e}")
+
     # User media Router - multipart upload + public serving for reels/posts
     try:
         from lyo_app.routers.user_media import router as user_media_router

--- a/lyo_app/models/clips.py
+++ b/lyo_app/models/clips.py
@@ -45,6 +45,7 @@ class Clip(Base):
     view_count = Column(Integer, default=0)
     like_count = Column(Integer, default=0)
     share_count = Column(Integer, default=0)
+    comment_count = Column(Integer, default=0)
     
     # Visibility
     is_public = Column(Boolean, default=True)
@@ -90,6 +91,7 @@ class Clip(Base):
             "viewCount": self.view_count,
             "likeCount": self.like_count,
             "shareCount": self.share_count,
+            "commentCount": self.comment_count or 0,
             "isLiked": False,  # Will be set by the API based on current user
             "isSaved": False,  # Will be set by the API based on current user
             "authorName": author_name,
@@ -125,6 +127,33 @@ class ClipSave(Base):
     # Relationships
     clip = relationship("Clip", back_populates="saves")
     user = relationship("User")
+
+
+class ClipComment(Base):
+    """Comment on a clip (denormalized author info, like community comments)."""
+    __tablename__ = "clip_comments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    clip_id = Column(Integer, ForeignKey("clips.id"), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    author_name = Column(String(150), default="")
+    author_avatar = Column(String(500), nullable=True)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    clip = relationship("Clip")
+    user = relationship("User")
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "clipId": str(self.clip_id),
+            "userId": self.user_id,
+            "authorName": self.author_name,
+            "authorAvatarURL": self.author_avatar,
+            "content": self.content,
+            "createdAt": self.created_at.isoformat() if self.created_at else None,
+        }
 
 
 class ClipView(Base):

--- a/lyo_app/routers/clips.py
+++ b/lyo_app/routers/clips.py
@@ -13,7 +13,7 @@ from sqlalchemy import select, func, desc
 from lyo_app.auth.jwt_auth import get_current_user
 from lyo_app.auth.models import User
 from lyo_app.core.database import get_async_session
-from lyo_app.models.clips import Clip, ClipLike, ClipView, ClipSave
+from lyo_app.models.clips import Clip, ClipLike, ClipView, ClipSave, ClipComment
 
 import logging
 
@@ -253,6 +253,71 @@ async def get_discover_clips(
         
     except Exception as e:
         logger.error(f"Error fetching discover clips: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )
+
+
+# NOTE: declared before "/{clip_id}" so the literal path wins route matching.
+@router.get("/saved", response_model=ClipsListResponse)
+async def get_saved_clips(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user)
+):
+    """Get clips saved by the current user."""
+    try:
+        offset = (page - 1) * per_page
+        
+        # Join with ClipSave
+        query = (
+            select(Clip)
+            .join(ClipSave, Clip.id == ClipSave.clip_id)
+            .where(ClipSave.user_id == current_user.id)
+            .order_by(desc(ClipSave.created_at))
+            .offset(offset)
+            .limit(per_page)
+        )
+        
+        # Count total
+        count_query = select(func.count()).select_from(ClipSave).where(
+            ClipSave.user_id == current_user.id
+        )
+        
+        total_result = await db.execute(count_query)
+        total = total_result.scalar() or 0
+        
+        result = await db.execute(query)
+        clips = result.scalars().all()
+        
+        # Populate isLiked and isSaved (which is always true here)
+        clip_dicts = []
+        for clip in clips:
+            clip_dict = clip.to_dict()
+            clip_dict["isSaved"] = True
+            
+            # Check isLiked
+            like_query = select(ClipLike).where(
+                ClipLike.clip_id == clip.id,
+                ClipLike.user_id == current_user.id
+            )
+            like_result = await db.execute(like_query)
+            clip_dict["isLiked"] = like_result.scalar() is not None
+            
+            clip_dicts.append(clip_dict)
+            
+        return ClipsListResponse(
+            success=True,
+            clips=clip_dicts,
+            total=total,
+            page=page,
+            perPage=per_page
+        )
+        
+    except Exception as e:
+        logger.error(f"Error fetching saved clips: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(e)
@@ -631,65 +696,142 @@ async def toggle_clip_save(
         )
 
 
-@router.get("/saved", response_model=ClipsListResponse)
-async def get_saved_clips(
-    page: int = Query(1, ge=1),
-    per_page: int = Query(20, ge=1, le=100),
+# ── Sharing ──────────────────────────────────────────────────────────────────
+
+@router.post("/{clip_id}/share")
+async def record_clip_share(
+    clip_id: int,
     db: AsyncSession = Depends(get_async_session),
     current_user: User = Depends(get_current_user)
 ):
-    """Get clips saved by the current user."""
+    """Record that a clip was shared (clients open the native share sheet)."""
     try:
-        offset = (page - 1) * per_page
-        
-        # Join with ClipSave
-        query = (
-            select(Clip)
-            .join(ClipSave, Clip.id == ClipSave.clip_id)
-            .where(ClipSave.user_id == current_user.id)
-            .order_by(desc(ClipSave.created_at))
-            .offset(offset)
+        result = await db.execute(select(Clip).where(Clip.id == clip_id))
+        clip = result.scalar_one_or_none()
+        if not clip:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found")
+
+        clip.share_count = (clip.share_count or 0) + 1
+        await db.commit()
+        return {"success": True, "shareCount": clip.share_count}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error recording clip share: {e}")
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+# ── Comments ─────────────────────────────────────────────────────────────────
+
+class ClipCommentCreate(BaseModel):
+    content: str = Field(..., min_length=1, max_length=2000)
+
+
+def _clip_author_display_name(user: User) -> str:
+    full = f"{getattr(user, 'first_name', None) or ''} {getattr(user, 'last_name', None) or ''}".strip()
+    return full or getattr(user, "username", None) or f"User {user.id}"
+
+
+@router.get("/{clip_id}/comments")
+async def list_clip_comments(
+    clip_id: int,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user)
+):
+    """List comments for a clip, newest first."""
+    try:
+        count_result = await db.execute(
+            select(func.count()).select_from(ClipComment).where(ClipComment.clip_id == clip_id)
+        )
+        total = count_result.scalar() or 0
+
+        result = await db.execute(
+            select(ClipComment)
+            .where(ClipComment.clip_id == clip_id)
+            .order_by(desc(ClipComment.created_at))
+            .offset((page - 1) * per_page)
             .limit(per_page)
         )
-        
-        # Count total
-        count_query = select(func.count()).select_from(ClipSave).where(
-            ClipSave.user_id == current_user.id
-        )
-        
-        total_result = await db.execute(count_query)
-        total = total_result.scalar() or 0
-        
-        result = await db.execute(query)
-        clips = result.scalars().all()
-        
-        # Populate isLiked and isSaved (which is always true here)
-        clip_dicts = []
-        for clip in clips:
-            clip_dict = clip.to_dict()
-            clip_dict["isSaved"] = True
-            
-            # Check isLiked
-            like_query = select(ClipLike).where(
-                ClipLike.clip_id == clip.id,
-                ClipLike.user_id == current_user.id
-            )
-            like_result = await db.execute(like_query)
-            clip_dict["isLiked"] = like_result.scalar() is not None
-            
-            clip_dicts.append(clip_dict)
-            
-        return ClipsListResponse(
-            success=True,
-            clips=clip_dicts,
-            total=total,
-            page=page,
-            perPage=per_page
-        )
-        
+        comments = result.scalars().all()
+        return {
+            "success": True,
+            "items": [c.to_dict() for c in comments],
+            "total_count": total,
+            "page": page,
+            "per_page": per_page,
+        }
     except Exception as e:
-        logger.error(f"Error fetching saved clips: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+        logger.error(f"Error listing clip comments: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.post("/{clip_id}/comments", status_code=status.HTTP_201_CREATED)
+async def create_clip_comment(
+    clip_id: int,
+    request: ClipCommentCreate,
+    db: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user)
+):
+    """Comment on a clip."""
+    try:
+        result = await db.execute(select(Clip).where(Clip.id == clip_id))
+        clip = result.scalar_one_or_none()
+        if not clip:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clip not found")
+
+        comment = ClipComment(
+            clip_id=clip_id,
+            user_id=current_user.id,
+            author_name=_clip_author_display_name(current_user),
+            author_avatar=getattr(current_user, "avatar_url", None),
+            content=request.content,
         )
+        db.add(comment)
+        clip.comment_count = (clip.comment_count or 0) + 1
+        await db.commit()
+        await db.refresh(comment)
+        return comment.to_dict()
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating clip comment: {e}")
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.delete("/{clip_id}/comments/{comment_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_clip_comment(
+    clip_id: int,
+    comment_id: int,
+    db: AsyncSession = Depends(get_async_session),
+    current_user: User = Depends(get_current_user)
+):
+    """Delete own comment on a clip (author only)."""
+    try:
+        result = await db.execute(
+            select(ClipComment).where(
+                ClipComment.id == comment_id, ClipComment.clip_id == clip_id
+            )
+        )
+        comment = result.scalar_one_or_none()
+        if not comment:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found")
+        if comment.user_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this comment")
+
+        clip_result = await db.execute(select(Clip).where(Clip.id == clip_id))
+        clip = clip_result.scalar_one_or_none()
+        if clip:
+            clip.comment_count = max(0, (clip.comment_count or 0) - 1)
+
+        await db.delete(comment)
+        await db.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting clip comment: {e}")
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))

--- a/lyo_app/routers/search.py
+++ b/lyo_app/routers/search.py
@@ -1,13 +1,19 @@
 """
-Search Router - AI-powered search functionality
+Search Router - cross-entity search over users, study groups, community
+events, and community posts. One endpoint, grouped results, so every
+client renders the same search experience.
 """
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
-from typing import Optional, List
 from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from lyo_app.auth.jwt_auth import get_current_user
 from lyo_app.auth.models import User
+from lyo_app.community.models import CommunityEvent, CommunityPost, StudyGroup, StudyGroupPrivacy
+from lyo_app.core.database import get_db
 
 router = APIRouter(prefix="/search", tags=["Search"])
 
@@ -16,72 +22,131 @@ class SearchType(str, Enum):
     """Types of searchable content."""
     ALL = "all"
     USERS = "users"
-    CONTENT = "content"
-    TOPICS = "topics"
-    RESOURCES = "resources"
+    GROUPS = "groups"
+    EVENTS = "events"
+    POSTS = "posts"
 
 
-class SearchResult(BaseModel):
-    """A search result item."""
-    id: str
-    type: str
-    title: str
-    description: Optional[str]
-    score: float
+def _display_name(user: User) -> str:
+    full = f"{user.first_name or ''} {user.last_name or ''}".strip()
+    return full or user.username or f"User {user.id}"
 
 
 @router.get("")
 async def search(
     q: str = Query(..., min_length=1, max_length=200, description="Search query"),
     type: SearchType = Query(default=SearchType.ALL, description="Filter by content type"),
-    limit: int = Query(default=20, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
-    current_user: User = Depends(get_current_user)
+    limit: int = Query(default=10, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
-    """
-    Search across all content types.
+    """Search users, study groups, community events, and posts."""
+    pattern = f"%{q.strip()}%"
+    users, groups, events, posts = [], [], [], []
 
-    AI-powered semantic search that understands intent and context.
-    """
+    if type in (SearchType.ALL, SearchType.USERS):
+        result = await db.execute(
+            select(User)
+            .where(
+                or_(
+                    User.username.ilike(pattern),
+                    User.first_name.ilike(pattern),
+                    User.last_name.ilike(pattern),
+                )
+            )
+            .order_by(User.username)
+            .limit(limit)
+        )
+        users = [
+            {
+                "id": u.id,
+                "username": u.username,
+                "name": _display_name(u),
+                "avatar_url": u.avatar_url,
+            }
+            for u in result.scalars().all()
+        ]
+
+    if type in (SearchType.ALL, SearchType.GROUPS):
+        result = await db.execute(
+            select(StudyGroup)
+            .where(
+                StudyGroup.privacy == StudyGroupPrivacy.PUBLIC,
+                or_(StudyGroup.name.ilike(pattern), StudyGroup.description.ilike(pattern)),
+            )
+            .order_by(StudyGroup.name)
+            .limit(limit)
+        )
+        groups = [
+            {
+                "id": g.id,
+                "name": g.name,
+                "description": g.description,
+                "privacy": g.privacy.value if g.privacy else "public",
+            }
+            for g in result.scalars().all()
+        ]
+
+    if type in (SearchType.ALL, SearchType.EVENTS):
+        result = await db.execute(
+            select(CommunityEvent)
+            .where(or_(CommunityEvent.title.ilike(pattern), CommunityEvent.description.ilike(pattern)))
+            .order_by(CommunityEvent.start_time)
+            .limit(limit)
+        )
+        events = [
+            {
+                "id": e.id,
+                "title": e.title,
+                "event_type": e.event_type.value if e.event_type else "other",
+                "start_time": e.start_time.isoformat() if e.start_time else None,
+                "end_time": e.end_time.isoformat() if e.end_time else None,
+                "location": e.location,
+                "is_online": bool(e.is_online),
+                "latitude": e.latitude,
+                "longitude": e.longitude,
+            }
+            for e in result.scalars().all()
+        ]
+
+    if type in (SearchType.ALL, SearchType.POSTS):
+        result = await db.execute(
+            select(CommunityPost)
+            .where(
+                CommunityPost.is_deleted == False,  # noqa: E712
+                CommunityPost.content.ilike(pattern),
+            )
+            .order_by(CommunityPost.created_at.desc())
+            .limit(limit)
+        )
+        posts = [
+            {
+                "id": str(p.id),
+                "content": (p.content[:200] + "…") if len(p.content or "") > 200 else p.content,
+                "author_name": p.author_name,
+                "created_at": p.created_at.isoformat() if p.created_at else None,
+            }
+            for p in result.scalars().all()
+        ]
+
     return {
         "query": q,
-        "type": type.value,
-        "results": [],
-        "total": 0,
-        "limit": limit,
-        "offset": offset
+        "users": users,
+        "groups": groups,
+        "events": events,
+        "posts": posts,
+        "total": len(users) + len(groups) + len(events) + len(posts),
     }
 
 
 @router.get("/suggestions")
 async def get_search_suggestions(
     q: str = Query(..., min_length=1, max_length=100),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ):
-    """Get autocomplete suggestions for search query."""
-    return {"suggestions": []}
-
-
-@router.get("/trending")
-async def get_trending_searches(
-    current_user: User = Depends(get_current_user)
-):
-    """Get trending search terms."""
-    return {"trending": []}
-
-
-@router.get("/recent")
-async def get_recent_searches(
-    limit: int = Query(default=10, ge=1, le=50),
-    current_user: User = Depends(get_current_user)
-):
-    """Get user's recent searches."""
-    return {"recent": []}
-
-
-@router.delete("/recent")
-async def clear_recent_searches(
-    current_user: User = Depends(get_current_user)
-):
-    """Clear user's search history."""
-    return {"status": "cleared"}
+    """Autocomplete: usernames and group names matching the prefix."""
+    pattern = f"{q.strip()}%"
+    names = await db.execute(select(User.username).where(User.username.ilike(pattern)).limit(5))
+    groups = await db.execute(select(StudyGroup.name).where(StudyGroup.name.ilike(pattern)).limit(5))
+    return {"suggestions": [*[n for (n,) in names.all()], *[g for (g,) in groups.all()]]}

--- a/lyo_app/routers/user_media.py
+++ b/lyo_app/routers/user_media.py
@@ -1,0 +1,115 @@
+"""
+Simple authenticated media upload + public serving for user content
+(reel videos, thumbnails, post images).
+
+This is the consumer-grade path every client uses via multipart POST —
+no presigned URLs and no organization gating. Files land under the
+local uploads directory; when cloud storage credentials are configured
+the enhanced storage service can replace the disk write transparently.
+Note Railway's container disk is ephemeral across redeploys, so cloud
+storage should be configured for durable production media.
+"""
+import logging
+import re
+import uuid
+from pathlib import Path
+
+import aiofiles
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
+from fastapi.responses import FileResponse
+
+from lyo_app.auth.jwt_auth import get_current_user
+from lyo_app.auth.models import User
+from lyo_app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/media", tags=["media"])
+
+ALLOWED_TYPES = {
+    "video/mp4": ".mp4",
+    "video/quicktime": ".mov",
+    "video/webm": ".webm",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+}
+MAX_VIDEO_BYTES = 200 * 1024 * 1024
+MAX_IMAGE_BYTES = 15 * 1024 * 1024
+_CHUNK = 1024 * 1024
+_FOLDER_RE = re.compile(r"^[a-z0-9_-]{1,64}$")
+
+
+def _media_root() -> Path:
+    root = Path(getattr(settings, "upload_dir", None) or "uploads") / "media"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@router.post("/upload")
+async def upload_media(
+    request: Request,
+    file: UploadFile = File(...),
+    folder: str = Form("content"),
+    current_user: User = Depends(get_current_user),
+):
+    """Upload a video or image; returns a public URL for the stored file."""
+    content_type = (file.content_type or "").split(";")[0].strip().lower()
+    if content_type not in ALLOWED_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported media type '{content_type}'. Allowed: {sorted(ALLOWED_TYPES)}",
+        )
+    if not _FOLDER_RE.match(folder):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid folder name")
+
+    max_bytes = MAX_VIDEO_BYTES if content_type.startswith("video/") else MAX_IMAGE_BYTES
+    name = f"{uuid.uuid4().hex}{ALLOWED_TYPES[content_type]}"
+    dest_dir = _media_root() / folder
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / name
+
+    size = 0
+    try:
+        async with aiofiles.open(dest, "wb") as out:
+            while True:
+                chunk = await file.read(_CHUNK)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > max_bytes:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)}MB",
+                    )
+                await out.write(chunk)
+    except HTTPException:
+        dest.unlink(missing_ok=True)
+        raise
+    except Exception as e:
+        dest.unlink(missing_ok=True)
+        logger.error(f"Media upload failed for user {current_user.id}: {e}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Upload failed")
+
+    path = f"/api/v1/media/file/{folder}/{name}"
+    absolute = str(request.base_url).rstrip("/") + path
+    logger.info(f"Media uploaded by user {current_user.id}: {path} ({size} bytes)")
+    return {
+        "success": True,
+        "url": absolute,
+        "path": path,
+        "contentType": content_type,
+        "size": size,
+    }
+
+
+@router.get("/file/{folder}/{name}")
+async def serve_media(folder: str, name: str):
+    """Serve an uploaded media file (public — reels and post images are public content)."""
+    if not _FOLDER_RE.match(folder) or "/" in name or ".." in name or name.startswith("."):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    path = _media_root() / folder / name
+    if not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return FileResponse(path)

--- a/lyo_app/storage/enhanced_storage.py
+++ b/lyo_app/storage/enhanced_storage.py
@@ -343,21 +343,21 @@ class EnhancedStorageSystem:
         
         try:
             # Initialize Redis for caching
-            if REDIS_AVAILABLE and settings.REDIS_URL:
+            if REDIS_AVAILABLE and getattr(settings, "redis_url", None):
                 self.redis_client = redis.from_url(
-                    settings.REDIS_URL,
+                    settings.redis_url,
                     encoding="utf-8",
                     decode_responses=True
                 )
                 logger.info("Redis client initialized")
             
             # Initialize AWS S3
-            if BOTO3_AVAILABLE and settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY:
+            if BOTO3_AVAILABLE and getattr(settings, "aws_access_key_id", None) and getattr(settings, "aws_secret_access_key", None):
                 self.s3_client = boto3.client(
                     's3',
-                    aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                    aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-                    region_name=settings.AWS_REGION or 'us-east-1'
+                    aws_access_key_id=settings.aws_access_key_id,
+                    aws_secret_access_key=settings.aws_secret_access_key,
+                    region_name=getattr(settings, "aws_region", None) or 'us-east-1'
                 )
                 logger.info("AWS S3 client initialized")
             
@@ -576,7 +576,7 @@ class EnhancedStorageSystem:
         """Upload to AWS S3"""
         
         self.s3_client.put_object(
-            Bucket=settings.AWS_S3_BUCKET,
+            Bucket=(getattr(settings, "storage_bucket", None) or getattr(settings, "gcs_bucket", None)),
             Key=storage_path,
             Body=file_data,
             ContentType=content_type,
@@ -605,7 +605,7 @@ class EnhancedStorageSystem:
     async def _upload_to_local(self, file_data: bytes, storage_path: str):
         """Upload to local storage"""
         
-        local_path = Path(settings.UPLOAD_DIR) / storage_path
+        local_path = Path(getattr(settings, "upload_dir", None) or "uploads") / storage_path
         local_path.parent.mkdir(parents=True, exist_ok=True)
         
         async with aiofiles.open(local_path, 'wb') as f:
@@ -658,14 +658,14 @@ class EnhancedStorageSystem:
         # Delete from S3
         if self.s3_client:
             try:
-                self.s3_client.delete_object(Bucket=settings.AWS_S3_BUCKET, Key=storage_path)
+                self.s3_client.delete_object(Bucket=(getattr(settings, "storage_bucket", None) or getattr(settings, "gcs_bucket", None)), Key=storage_path)
             except Exception as e:
                 logger.warning(f"S3 deletion failed: {e}")
                 success = False
         
         # Delete from local storage
         try:
-            local_path = Path(settings.UPLOAD_DIR) / storage_path
+            local_path = Path(getattr(settings, "upload_dir", None) or "uploads") / storage_path
             if local_path.exists():
                 local_path.unlink()
         except Exception as e:


### PR DESCRIPTION
End-to-end exercising of the Discover/reels surface found four gaps that kept it from being fully operational:

1. **Saved reels were unreachable**: `GET /api/v1/clips/saved` always returned 422 because the `/{clip_id}` route was declared first and "saved" was parsed as a clip id. The literal route now precedes the parameterized one.
2. **Uploads could never work**: the storage module read UPPERCASE settings (`REDIS_URL`, `AWS_ACCESS_KEY_ID`, `AWS_S3_BUCKET`, `UPLOAD_DIR`) that don't exist on the lowercase-field `Settings` model, so the storage client crashed with `AttributeError` on init. All references now use the real config fields with safe fallbacks. (Actual uploads still require storage credentials configured on Railway.)
3. **No clip comments existed** even though every client renders a comment button and count. Adds `ClipComment` (denormalized author, matching community comments), `clips.comment_count`, migration `clips_sync_001`, and `GET/POST/DELETE /api/v1/clips/{id}/comments[/{comment_id}]` with author-only delete (403 for others).
4. **Nothing incremented `share_count`**. Adds `POST /api/v1/clips/{id}/share` for clients to record a native-share.

## Verification

- Two-user HTTP E2E on a fresh DB: create clip → save → **saved list 200** (was 422) → share increments → comment create/list, `commentCount` denormalized on the clip, foreign delete → 403, own delete → 204 — **10/10 pass**
- Full test suite: **207 passed, 6 skipped** (unchanged — no regressions)
- Alembic chain has a single head (`clips_sync_001` → `community_sync_001` → `chat_004`)

Client-side wiring (iOS upload path fix, web/Android share + comments + creation) lands in a companion Lyo_Da_One PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVuFK6uNvSiZCrDQSEw3YV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVuFK6uNvSiZCrDQSEw3YV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds user-generated comments and public media serving plus a schema migration; storage config changes affect upload paths in production when credentials are set.
> 
> **Overview**
> Makes the **clips (reels) surface** usable end-to-end: **`GET /clips/saved`** is registered **before** `/{clip_id}` so it no longer 422s, adds **`POST /clips/{id}/share`** to bump **`share_count`**, and introduces **clip comments** (`ClipComment`, denormalized author fields, **`comment_count`**, migration **`clips_sync_001`**, list/create/delete with author-only delete).
> 
> **`enhanced_storage`** now reads **lowercase `Settings` fields** via `getattr` (Redis, AWS keys, bucket, `upload_dir`) so storage init no longer throws on missing UPPERCASE attributes.
> 
> Adds **`/api/v1/media`** for **authenticated multipart upload** and **public file serving** (type/size limits, folder validation), and wires **search** plus **user media** into **`enhanced_main`**.
> 
> Replaces the stub **`/api/v1/search`** with **DB-backed cross-entity search** (users, public groups, events, posts) plus **username/group-name suggestions**; study-group and event list endpoints gain optional **`q`** **ILIKE** filters in the community service.
> 
> Clip payloads now expose **`commentCount`** in **`to_dict`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c23815e6ab11a31f337c897048aaa5d654043e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->