### PR TITLE
Patch fixable base-image CVEs so the release-image scan passes

### DIFF
--- a/deployment/Dockerfile.production
+++ b/deployment/Dockerfile.production
@@ -13,8 +13,10 @@ FROM python:3.12-slim as builder
 LABEL maintainer="Lyo AI Team <team@lyo.ai>"
 LABEL description="Living Classroom - Production-ready AI learning platform"
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
+# Install build dependencies (upgrade base OS packages first to patch
+# fixable CVEs shipped in the base image layer)
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     git \
@@ -42,8 +44,10 @@ FROM python:3.12-slim
 # Create non-root user for security
 RUN groupadd -r lyo && useradd -r -g lyo lyo
 
-# Install runtime dependencies only
-RUN apt-get update && apt-get install -y \
+# Install runtime dependencies only (upgrade base OS packages first so the
+# final scanned image carries patched versions of fixable CVEs)
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean


### PR DESCRIPTION
## Summary

The `Backend CI and release image` workflow goes red on `main` at the **Scan immutable release image** (Trivy) job. It fails on HIGH/CRITICAL vulnerabilities **even though `ignore-unfixed: true` is already set** — which means the scanned image ships packages that have fixes *available*, not just unpatchable OS CVEs.

Root cause: `deployment/Dockerfile.production` installs a few packages but never upgrades the ones baked into the `python:3.12-slim` base layer, so those stay at their vulnerable shipped versions.

## Type of Change

- [x] CI/CD changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Add `apt-get upgrade -y` to the **builder** and the **final runtime** stage of `deployment/Dockerfile.production` so the scanned image carries patched OS packages.
- Add `--no-install-recommends` to the `apt-get install` steps to keep the attack surface minimal.
- No base-image change, no dependency changes, no application-behaviour change.

## Testing

- [x] All existing tests pass locally / in the `test` job (Dockerfile changes don't affect the Python test suite).

Note on verification: the image `build` and Trivy `scan` jobs are gated to non-PR / `main` respectively, so the scan can only be validated on the post-merge `main` run — that run is the confirmation that the gate is now green.

## Deployment Notes

- [x] No special deployment steps required. Railway owns production deployment via its GitHub integration; this workflow only proves the revision and publishes the immutable image.

## Additional Context

Independent of the cross-platform feature work; this only hardens the production image so the security gate reflects reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVuFK6uNvSiZCrDQSEw3YV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVuFK6uNvSiZCrDQSEw3YV)_

## Summary by Sourcery

Update the production Dockerfile to ensure the release image passes Trivy security scans by upgrading OS packages in the base image.

CI:
- Adjust release image build configuration so CI Trivy scans no longer fail on fixable base-image CVEs.

Deployment:
- Harden the production container image by upgrading base OS packages and limiting installed recommendations in the Docker build process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Docker build-only change with no application or dependency logic changes; main risk is slightly longer builds or rare apt upgrade surprises in the slim image.
> 
> **Overview**
> **Hardens the production Docker image** so Trivy’s release scan stops failing on HIGH/CRITICAL issues that already have fixes (`ignore-unfixed: true` was not enough).
> 
> In `deployment/Dockerfile.production`, both the **builder** and **final runtime** stages now run `apt-get upgrade -y` before installing packages, so OS packages from `python:3.12-slim` are patched instead of left at the base-layer versions. `apt-get install` also uses `--no-install-recommends` in those steps to avoid pulling extra packages.
> 
> No base image, Python deps, or app behavior changes—only image build steps for CI/security scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d903efd10dd504d17644a3443363561c58f7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->