### PR TITLE
Fix production chat router media signature

### DIFF
--- a/lyo_app/ai/router.py
+++ b/lyo_app/ai/router.py
@@ -63,7 +63,16 @@ Lyo is an Outcome Engine for learning.
 YOU MUST RESPOND ONLY WITH JSON.
 """
 
-    def build_prompt(self, request: RouterRequest) -> str:
+    def build_prompt(
+        self,
+        request: RouterRequest,
+        media_attachments: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        # media_attachments are passed separately to the model by BaseAgent.
+        # Accept them here because BaseAgent forwards all execute() kwargs to
+        # build_prompt before constructing the multimodal model payload.
+        # The RouterRequest media references below remain useful textual context.
+        _ = media_attachments
         # Construct the user prompt based on the request
         prompt_parts = []
 

--- a/tests/test_multimodal_router_contract.py
+++ b/tests/test_multimodal_router_contract.py
@@ -1,0 +1,28 @@
+"""Regression contract for the Lyo 2.0 multimodal router."""
+
+from lyo_app.ai.router import MultimodalRouter
+from lyo_app.ai.schemas.lyo2 import RouterRequest
+
+
+def test_build_prompt_accepts_media_attachments_forwarded_by_base_agent():
+    """BaseAgent.execute forwards every kwarg to build_prompt.
+
+    The streaming route calls MultimodalRouter.route with media_attachments,
+    so build_prompt must accept that kwarg even though the attachments are
+    passed to the model separately.
+    """
+    router = object.__new__(MultimodalRouter)
+    request = RouterRequest(text="Hi")
+
+    prompt = router.build_prompt(
+        request=request,
+        media_attachments=[
+            {
+                "type": "image",
+                "data": "diagnostic",
+                "mime_type": "image/jpeg",
+            }
+        ],
+    )
+
+    assert "USER TEXT: Hi" in prompt


### PR DESCRIPTION
## What changed

- Updated `MultimodalRouter.build_prompt` to accept the `media_attachments` keyword forwarded by `BaseAgent.execute`.
- Kept binary/media payload delivery in the existing model call path.
- Added a regression test for the exact production call shape.

## Root cause

The production SSE route called `MultimodalRouter.route(..., media_attachments=...)`. The router passed that keyword through `BaseAgent.execute`, which forwards all execution kwargs into `build_prompt`. The router override only accepted `request`, causing every chat response to terminate with:

`MultimodalRouter.build_prompt() got an unexpected keyword argument 'media_attachments'`

Authentication was healthy; the failure occurred after the conversation and skeleton events were emitted.

## Impact

Restores AI chat responses for authenticated web users and preserves multimodal routing.

## Validation

- Reproduced against production with a temporary account.
- Confirmed registration and `/auth/me` returned 200.
- Confirmed the stream reached the router and emitted the exact signature error.
- Added `tests/test_multimodal_router_contract.py` to prevent recurrence.

## Summary by Sourcery

Accept media attachments in the multimodal chat router prompt builder to restore the production streaming route call signature.

Bug Fixes:
- Fix MultimodalRouter.build_prompt to accept the media_attachments keyword forwarded by BaseAgent.execute, preventing runtime errors in the production SSE chat route.

Tests:
- Add a regression contract test ensuring MultimodalRouter.build_prompt accepts media_attachments and still produces the expected user prompt text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow signature fix with no change to routing logic or how media is sent to the model; covered by a small regression test.
> 
> **Overview**
> Fixes a production-breaking mismatch where **`MultimodalRouter.build_prompt`** only accepted `request` while **`BaseAgent.execute`** forwards all `execute()` kwargs (including `media_attachments` from the SSE chat route), which raised an unexpected keyword error and ended every chat stream after skeleton events.
> 
> **`build_prompt`** now takes an optional **`media_attachments`** argument for signature compatibility; attachments are still delivered on the existing multimodal model path, not woven into the text prompt. A regression test locks in the production call shape and asserts prompt text still includes the user message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82373a2ffdba8ff893f38bba27e0907fa8c9ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->