### PR TITLE
Community: add map-first Learning Around API

### DIFF
--- a/alembic/versions/community_map_001_learning_around.py
+++ b/alembic/versions/community_map_001_learning_around.py
@@ -1,0 +1,126 @@
+"""Add the cross-platform Learning Around Me account contract.
+
+Revision ID: community_map_001
+Revises: chat_blocks_001
+Create Date: 2026-08-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "community_map_001"
+down_revision = "chat_blocks_001"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _columns(table: str) -> set[str]:
+    if not _has_table(table):
+        return set()
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table)}
+
+
+def _indexes(table: str) -> set[str]:
+    if not _has_table(table):
+        return set()
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table)}
+
+
+def _add_column(table: str, column: sa.Column) -> None:
+    if _has_table(table) and column.name not in _columns(table):
+        op.add_column(table, column)
+
+
+def _add_index(table: str, name: str, columns: list[str]) -> None:
+    if _has_table(table) and name not in _indexes(table):
+        op.create_index(name, table, columns, unique=False)
+
+
+def upgrade() -> None:
+    # These event fields existed in the ORM/client contract but never had a
+    # canonical migration, which is why created map pins could disappear in
+    # production even though tests built from metadata passed.
+    _add_column(
+        "community_events",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("community_events", sa.Column("latitude", sa.Float(), nullable=True))
+    _add_column("community_events", sa.Column("longitude", sa.Float(), nullable=True))
+    _add_column("community_events", sa.Column("room_id", sa.String(100), nullable=True))
+    _add_column("community_events", sa.Column("image_url", sa.String(500), nullable=True))
+    _add_index("community_events", "ix_community_events_latitude", ["latitude"])
+    _add_index("community_events", "ix_community_events_longitude", ["longitude"])
+
+    _add_column("study_groups", sa.Column("location", sa.String(300), nullable=True))
+    _add_column(
+        "study_groups",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("study_groups", sa.Column("meeting_url", sa.String(500), nullable=True))
+    _add_column("study_groups", sa.Column("latitude", sa.Float(), nullable=True))
+    _add_column("study_groups", sa.Column("longitude", sa.Float(), nullable=True))
+    _add_column("study_groups", sa.Column("image_url", sa.String(500), nullable=True))
+    _add_index("study_groups", "ix_study_groups_latitude", ["latitude"])
+    _add_index("study_groups", "ix_study_groups_longitude", ["longitude"])
+
+    _add_column(
+        "private_lessons",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("private_lessons", sa.Column("meeting_url", sa.String(500), nullable=True))
+    _add_column("private_lessons", sa.Column("image_url", sa.String(500), nullable=True))
+
+    if not _has_table("community_saved_nodes"):
+        op.create_table(
+            "community_saved_nodes",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("node_kind", sa.String(50), nullable=False),
+            sa.Column("node_id", sa.String(255), nullable=False),
+            sa.Column("snapshot", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint(
+                "user_id",
+                "node_kind",
+                "node_id",
+                name="uq_community_saved_node_user_kind_id",
+            ),
+        )
+        op.create_index("ix_community_saved_nodes_id", "community_saved_nodes", ["id"])
+        op.create_index("ix_community_saved_nodes_user_id", "community_saved_nodes", ["user_id"])
+        op.create_index("ix_community_saved_nodes_node_kind", "community_saved_nodes", ["node_kind"])
+        op.create_index("ix_community_saved_nodes_node_id", "community_saved_nodes", ["node_id"])
+
+    # SQLAlchemy persists enum member names for this legacy type.
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'OFFICE_HOURS'")
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'CLASS'")
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'SEMINAR'")
+
+
+def downgrade() -> None:
+    if _has_table("community_saved_nodes"):
+        op.drop_table("community_saved_nodes")
+
+    for table, columns in (
+        ("private_lessons", ["image_url", "meeting_url", "is_online"]),
+        (
+            "study_groups",
+            ["image_url", "longitude", "latitude", "meeting_url", "is_online", "location"],
+        ),
+        (
+            "community_events",
+            ["image_url", "room_id", "longitude", "latitude", "is_online"],
+        ),
+    ):
+        existing = _columns(table)
+        for column in columns:
+            if column in existing:
+                op.drop_column(table, column)
+
+    # PostgreSQL enum values cannot be safely removed in a downgrade.

--- a/lyo_app/community/learning_around.py
+++ b/lyo_app/community/learning_around.py
@@ -1,0 +1,678 @@
+"""Canonical map-first Community discovery and account state.
+
+This module deliberately sits behind one authenticated API contract. Native
+map SDKs may differ by platform, but the nodes, memberships, attendance,
+saves, and connections always come from the same user-owned backend rows.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+from datetime import datetime
+from typing import Optional, Set
+
+import httpx
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from lyo_app.auth.models import User
+from lyo_app.community.models import (
+    AttendanceStatus,
+    CommunityEvent,
+    CommunitySavedNode,
+    EventAttendance,
+    EventStatus,
+    EventType,
+    GroupMembership,
+    PrivateLesson,
+    StudyGroup,
+    StudyGroupPrivacy,
+    StudyGroupStatus,
+)
+from lyo_app.community.schemas import (
+    CommunityEventRead,
+    CommunityMeResponse,
+    LearningNode,
+    LearningNodeCategory,
+    LearningNodeKind,
+    NearbyLearningResponse,
+    StudyGroupRead,
+    UserPreview,
+)
+from lyo_app.feeds.models import UserFollow
+
+logger = logging.getLogger(__name__)
+
+
+def _display_name(user: Optional[User]) -> str:
+    if user is None:
+        return ""
+    full_name = f"{user.first_name or ''} {user.last_name or ''}".strip()
+    return full_name or user.username
+
+
+def _preview(user: Optional[User]) -> Optional[UserPreview]:
+    if user is None:
+        return None
+    return UserPreview(id=user.id, name=_display_name(user), avatar=user.avatar_url)
+
+
+def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    radius = 6371.0088
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    delta_phi = math.radians(lat2 - lat1)
+    delta_lng = math.radians(lng2 - lng1)
+    value = (
+        math.sin(delta_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(delta_lng / 2) ** 2
+    )
+    return radius * 2 * math.atan2(math.sqrt(value), math.sqrt(1 - value))
+
+
+def _bounds(lat: float, lng: float, radius_km: float) -> tuple[float, float, float, float]:
+    lat_delta = radius_km / 111.0
+    longitude_scale = max(math.cos(math.radians(lat)), 0.15)
+    lng_delta = radius_km / (111.0 * longitude_scale)
+    return lat - lat_delta, lat + lat_delta, lng - lng_delta, lng + lng_delta
+
+
+def _event_category(event_type: EventType) -> LearningNodeCategory:
+    if event_type == EventType.WORKSHOP:
+        return LearningNodeCategory.WORKSHOP
+    if event_type in {
+        EventType.CLASS,
+        EventType.SEMINAR,
+        EventType.LECTURE,
+        EventType.OFFICE_HOURS,
+    }:
+        return LearningNodeCategory.CLASS
+    return LearningNodeCategory.EVENT
+
+
+class LearningAroundService:
+    """Builds the shared Learning Around Me view and My Community state."""
+
+    _poi_cache: dict[tuple[float, float, float], tuple[float, list[LearningNode]]] = {}
+    _poi_cache_ttl_seconds = 300
+
+    async def get_nearby(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int,
+        latitude: float,
+        longitude: float,
+        radius_km: float,
+        categories: Optional[Set[LearningNodeCategory]] = None,
+        query_text: Optional[str] = None,
+        include_online: bool = True,
+        include_institutions: bool = True,
+        limit: int = 100,
+    ) -> NearbyLearningResponse:
+        categories = categories or set(LearningNodeCategory)
+        search = query_text.strip().lower() if query_text else None
+        south, north, west, east = _bounds(latitude, longitude, radius_km)
+
+        saved_keys = await self._saved_keys(db, user_id)
+        joined_group_ids = await self._joined_group_ids(db, user_id)
+        attending_event_ids = await self._attending_event_ids(db, user_id)
+
+        items: list[LearningNode] = []
+
+        event_categories = {
+            LearningNodeCategory.EVENT,
+            LearningNodeCategory.WORKSHOP,
+            LearningNodeCategory.CLASS,
+        }
+        if categories.intersection(event_categories):
+            event_location = and_(
+                CommunityEvent.latitude.between(south, north),
+                CommunityEvent.longitude.between(west, east),
+            )
+            if include_online:
+                event_location = or_(event_location, CommunityEvent.is_online.is_(True))
+            result = await db.execute(
+                select(CommunityEvent)
+                .options(
+                    selectinload(CommunityEvent.organizer),
+                    selectinload(CommunityEvent.attendances),
+                )
+                .where(
+                    CommunityEvent.status.in_([EventStatus.SCHEDULED, EventStatus.ONGOING]),
+                    CommunityEvent.end_time >= datetime.utcnow(),
+                    event_location,
+                )
+                .order_by(CommunityEvent.start_time)
+                .limit(max(limit * 2, 100))
+            )
+            for event in result.scalars().all():
+                category = _event_category(event.event_type)
+                if category not in categories:
+                    continue
+                node = self._event_node(
+                    event,
+                    latitude,
+                    longitude,
+                    saved_keys,
+                    attending_event_ids,
+                )
+                if self._within_scope(node, radius_km, include_online, search):
+                    items.append(node)
+
+        if LearningNodeCategory.STUDY_GROUP in categories:
+            group_location = and_(
+                StudyGroup.latitude.between(south, north),
+                StudyGroup.longitude.between(west, east),
+            )
+            if include_online:
+                group_location = or_(group_location, StudyGroup.is_online.is_(True))
+            result = await db.execute(
+                select(StudyGroup)
+                .options(
+                    selectinload(StudyGroup.creator),
+                    selectinload(StudyGroup.memberships),
+                )
+                .where(
+                    StudyGroup.status == StudyGroupStatus.ACTIVE,
+                    or_(
+                        StudyGroup.privacy == StudyGroupPrivacy.PUBLIC,
+                        StudyGroup.id.in_(joined_group_ids or [-1]),
+                    ),
+                    group_location,
+                )
+                .order_by(StudyGroup.updated_at.desc())
+                .limit(max(limit * 2, 100))
+            )
+            for group in result.scalars().all():
+                member_count = sum(1 for membership in group.memberships if membership.is_approved)
+                node = self._group_node(
+                    group,
+                    latitude,
+                    longitude,
+                    saved_keys,
+                    joined_group_ids,
+                    member_count,
+                )
+                if self._within_scope(node, radius_km, include_online, search):
+                    items.append(node)
+
+        if LearningNodeCategory.TUTOR in categories:
+            lesson_location = and_(
+                PrivateLesson.latitude.between(south, north),
+                PrivateLesson.longitude.between(west, east),
+            )
+            if include_online:
+                lesson_location = or_(lesson_location, PrivateLesson.is_online.is_(True))
+            result = await db.execute(
+                select(PrivateLesson)
+                .options(selectinload(PrivateLesson.instructor))
+                .where(PrivateLesson.is_active.is_(True), lesson_location)
+                .order_by(PrivateLesson.updated_at.desc())
+                .limit(max(limit * 2, 100))
+            )
+            for lesson in result.scalars().all():
+                node = self._lesson_node(
+                    lesson,
+                    latitude,
+                    longitude,
+                    saved_keys,
+                )
+                if self._within_scope(node, radius_km, include_online, search):
+                    items.append(node)
+
+        institution_categories = {
+            LearningNodeCategory.LIBRARY,
+            LearningNodeCategory.MUSEUM,
+            LearningNodeCategory.EDUCATIONAL_CENTER,
+        }
+        if include_institutions and categories.intersection(institution_categories):
+            places = await self._fetch_osm_places(latitude, longitude, radius_km)
+            for node in places:
+                if node.category not in categories:
+                    continue
+                node.is_saved = node.key in saved_keys
+                if self._within_scope(node, radius_km, False, search):
+                    items.append(node)
+
+        items.sort(
+            key=lambda item: (
+                item.distance_km is None,
+                item.distance_km if item.distance_km is not None else float("inf"),
+                item.starts_at or datetime.max,
+                item.title.lower(),
+            )
+        )
+        return NearbyLearningResponse(
+            items=items[:limit],
+            center_latitude=latitude,
+            center_longitude=longitude,
+            radius_km=radius_km,
+            fetched_at=datetime.utcnow(),
+        )
+
+    async def get_my_community(self, db: AsyncSession, user_id: int) -> CommunityMeResponse:
+        joined_result = await db.execute(
+            select(StudyGroup)
+            .join(GroupMembership, GroupMembership.study_group_id == StudyGroup.id)
+            .where(
+                GroupMembership.user_id == user_id,
+                GroupMembership.is_approved.is_(True),
+            )
+            .order_by(StudyGroup.updated_at.desc())
+        )
+        groups = list(joined_result.scalars().all())
+
+        attending_ids = await self._attending_event_ids(db, user_id)
+        event_result = await db.execute(
+            select(CommunityEvent)
+            .where(
+                or_(
+                    CommunityEvent.organizer_id == user_id,
+                    CommunityEvent.id.in_(attending_ids or [-1]),
+                ),
+                CommunityEvent.end_time >= datetime.utcnow(),
+            )
+            .order_by(CommunityEvent.start_time)
+        )
+        events = list(event_result.scalars().all())
+
+        follow_result = await db.execute(
+            select(User)
+            .join(UserFollow, UserFollow.following_id == User.id)
+            .where(UserFollow.follower_id == user_id)
+            .order_by(User.first_name, User.last_name, User.username)
+        )
+        following = [preview for user in follow_result.scalars().all() if (preview := _preview(user))]
+
+        return CommunityMeResponse(
+            joined_groups=[StudyGroupRead.model_validate(group) for group in groups],
+            attending_events=[CommunityEventRead.model_validate(event) for event in events],
+            saved_nodes=await self.get_saved_nodes(db, user_id),
+            following=following,
+            updated_at=datetime.utcnow(),
+        )
+
+    async def save_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int,
+        kind: LearningNodeKind,
+        node_id: str,
+        snapshot: LearningNode,
+    ) -> LearningNode:
+        if snapshot.kind != kind or snapshot.id != node_id:
+            raise ValueError("Saved node identity does not match its snapshot")
+
+        result = await db.execute(
+            select(CommunitySavedNode).where(
+                CommunitySavedNode.user_id == user_id,
+                CommunitySavedNode.node_kind == kind.value,
+                CommunitySavedNode.node_id == node_id,
+            )
+        )
+        saved = result.scalar_one_or_none()
+        snapshot.is_saved = True
+        # Never turn a private meeting link into a durable client-provided
+        # snapshot. Authorized members receive links from canonical rows.
+        stored_snapshot = snapshot.model_copy(update={"meeting_url": None})
+        payload = stored_snapshot.model_dump(mode="json")
+        if saved:
+            saved.snapshot = payload
+            saved.updated_at = datetime.utcnow()
+        else:
+            saved = CommunitySavedNode(
+                user_id=user_id,
+                node_kind=kind.value,
+                node_id=node_id,
+                snapshot=payload,
+            )
+            db.add(saved)
+        await db.commit()
+        return snapshot
+
+    async def unsave_node(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int,
+        kind: LearningNodeKind,
+        node_id: str,
+    ) -> bool:
+        result = await db.execute(
+            select(CommunitySavedNode).where(
+                CommunitySavedNode.user_id == user_id,
+                CommunitySavedNode.node_kind == kind.value,
+                CommunitySavedNode.node_id == node_id,
+            )
+        )
+        saved = result.scalar_one_or_none()
+        if saved is None:
+            return False
+        await db.delete(saved)
+        await db.commit()
+        return True
+
+    async def get_saved_nodes(self, db: AsyncSession, user_id: int) -> list[LearningNode]:
+        joined_ids = await self._joined_group_ids(db, user_id)
+        attending_ids = await self._attending_event_ids(db, user_id)
+        result = await db.execute(
+            select(CommunitySavedNode)
+            .where(CommunitySavedNode.user_id == user_id)
+            .order_by(CommunitySavedNode.updated_at.desc())
+        )
+        nodes: list[LearningNode] = []
+        for saved in result.scalars().all():
+            try:
+                node = LearningNode.model_validate(saved.snapshot)
+                node.is_saved = True
+                node.is_joined = (
+                    node.kind == LearningNodeKind.STUDY_GROUP
+                    and node.id.isdigit()
+                    and int(node.id) in joined_ids
+                )
+                node.is_attending = (
+                    node.kind == LearningNodeKind.EVENT
+                    and node.id.isdigit()
+                    and int(node.id) in attending_ids
+                )
+                node.meeting_url = None
+                nodes.append(node)
+            except Exception as exc:  # A bad legacy snapshot must not break all account state.
+                logger.warning("Skipping invalid saved Community node %s: %s", saved.id, exc)
+        return nodes
+
+    @staticmethod
+    def _within_scope(
+        node: LearningNode,
+        radius_km: float,
+        include_online: bool,
+        search: Optional[str],
+    ) -> bool:
+        if (
+            node.distance_km is not None
+            and node.distance_km > radius_km
+            and not (include_online and node.is_online)
+        ):
+            return False
+        if node.distance_km is None and not (include_online and node.is_online):
+            return False
+        if search:
+            searchable = " ".join(
+                value for value in [node.title, node.description, node.location_name] if value
+            ).lower()
+            if search not in searchable:
+                return False
+        return True
+
+    @staticmethod
+    def _distance(
+        latitude: float,
+        longitude: float,
+        node_latitude: Optional[float],
+        node_longitude: Optional[float],
+    ) -> Optional[float]:
+        if node_latitude is None or node_longitude is None:
+            return None
+        return round(_haversine_km(latitude, longitude, node_latitude, node_longitude), 2)
+
+    def _event_node(
+        self,
+        event: CommunityEvent,
+        latitude: float,
+        longitude: float,
+        saved_keys: Set[str],
+        attending_ids: Set[int],
+    ) -> LearningNode:
+        node_id = str(event.id)
+        key = f"{LearningNodeKind.EVENT.value}:{node_id}"
+        return LearningNode(
+            key=key,
+            kind=LearningNodeKind.EVENT,
+            category=_event_category(event.event_type),
+            id=node_id,
+            title=event.title,
+            description=event.description,
+            latitude=event.latitude,
+            longitude=event.longitude,
+            distance_km=self._distance(latitude, longitude, event.latitude, event.longitude),
+            location_name=event.location,
+            is_online=event.is_online,
+            meeting_url=event.meeting_url if event.id in attending_ids else None,
+            starts_at=event.start_time,
+            ends_at=event.end_time,
+            timezone=event.timezone,
+            host=_preview(event.organizer),
+            attendee_count=(
+                sum(
+                    1
+                    for attendance in event.attendances
+                    if attendance.status
+                    in {
+                        AttendanceStatus.GOING,
+                        AttendanceStatus.MAYBE,
+                        AttendanceStatus.ATTENDED,
+                    }
+                )
+                if "attendances" in event.__dict__
+                else None
+            ),
+            capacity=event.max_attendees,
+            is_attending=event.id in attending_ids,
+            is_saved=key in saved_keys,
+            course_id=event.course_id,
+            lesson_id=event.lesson_id,
+            study_group_id=event.study_group_id,
+            image_url=event.image_url,
+        )
+
+    def _group_node(
+        self,
+        group: StudyGroup,
+        latitude: float,
+        longitude: float,
+        saved_keys: Set[str],
+        joined_ids: Set[int],
+        member_count: int,
+    ) -> LearningNode:
+        node_id = str(group.id)
+        key = f"{LearningNodeKind.STUDY_GROUP.value}:{node_id}"
+        return LearningNode(
+            key=key,
+            kind=LearningNodeKind.STUDY_GROUP,
+            category=LearningNodeCategory.STUDY_GROUP,
+            id=node_id,
+            title=group.name,
+            description=group.description,
+            latitude=group.latitude,
+            longitude=group.longitude,
+            distance_km=self._distance(latitude, longitude, group.latitude, group.longitude),
+            location_name=group.location,
+            is_online=group.is_online,
+            meeting_url=group.meeting_url if group.id in joined_ids else None,
+            host=_preview(group.creator),
+            member_count=member_count,
+            capacity=group.max_members,
+            is_joined=group.id in joined_ids,
+            is_saved=key in saved_keys,
+            course_id=group.course_id,
+            study_group_id=group.id,
+            image_url=group.image_url,
+        )
+
+    def _lesson_node(
+        self,
+        lesson: PrivateLesson,
+        latitude: float,
+        longitude: float,
+        saved_keys: Set[str],
+    ) -> LearningNode:
+        node_id = str(lesson.id)
+        key = f"{LearningNodeKind.PRIVATE_LESSON.value}:{node_id}"
+        price = f"{lesson.currency} {lesson.price_per_hour:g}/hour"
+        description = " · ".join(value for value in [lesson.subject, price, lesson.description] if value)
+        return LearningNode(
+            key=key,
+            kind=LearningNodeKind.PRIVATE_LESSON,
+            category=LearningNodeCategory.TUTOR,
+            id=node_id,
+            title=lesson.title,
+            description=description,
+            latitude=lesson.latitude,
+            longitude=lesson.longitude,
+            distance_km=self._distance(latitude, longitude, lesson.latitude, lesson.longitude),
+            location_name=lesson.location,
+            is_online=lesson.is_online,
+            # The public map advertises the lesson; the private meeting link is
+            # released through the booking flow, never through discovery.
+            meeting_url=None,
+            host=_preview(lesson.instructor),
+            is_saved=key in saved_keys,
+            image_url=lesson.image_url,
+        )
+
+    async def _saved_keys(self, db: AsyncSession, user_id: int) -> Set[str]:
+        result = await db.execute(
+            select(CommunitySavedNode.node_kind, CommunitySavedNode.node_id).where(
+                CommunitySavedNode.user_id == user_id
+            )
+        )
+        return {f"{kind}:{node_id}" for kind, node_id in result.all()}
+
+    async def _joined_group_ids(self, db: AsyncSession, user_id: int) -> Set[int]:
+        result = await db.execute(
+            select(GroupMembership.study_group_id).where(
+                GroupMembership.user_id == user_id,
+                GroupMembership.is_approved.is_(True),
+            )
+        )
+        return set(result.scalars().all())
+
+    async def _attending_event_ids(self, db: AsyncSession, user_id: int) -> Set[int]:
+        result = await db.execute(
+            select(EventAttendance.event_id).where(
+                EventAttendance.user_id == user_id,
+                EventAttendance.status.in_(
+                    [AttendanceStatus.GOING, AttendanceStatus.MAYBE, AttendanceStatus.ATTENDED]
+                ),
+            )
+        )
+        return set(result.scalars().all())
+
+    async def _fetch_osm_places(
+        self,
+        latitude: float,
+        longitude: float,
+        radius_km: float,
+    ) -> list[LearningNode]:
+        cache_key = (round(latitude, 3), round(longitude, 3), round(radius_km, 1))
+        cached = self._poi_cache.get(cache_key)
+        if cached and time.monotonic() - cached[0] < self._poi_cache_ttl_seconds:
+            return [node.model_copy(deep=True) for node in cached[1]]
+
+        endpoint = os.getenv("COMMUNITY_OVERPASS_URL", "https://overpass-api.de/api/interpreter")
+        if not endpoint:
+            return []
+
+        south, north, west, east = _bounds(latitude, longitude, radius_km)
+        bbox = f"{south:.6f},{west:.6f},{north:.6f},{east:.6f}"
+        overpass_query = f"""
+        [out:json][timeout:8];
+        (
+          nwr[\"amenity\"~\"^(library|college|university|school|language_school|music_school)$\"]({bbox});
+          nwr[\"tourism\"=\"museum\"]({bbox});
+          nwr[\"amenity\"=\"community_centre\"][\"community_centre\"~\"education|language|culture\"]({bbox});
+        );
+        out center tags;
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+                response = await client.post(
+                    endpoint,
+                    data={"data": overpass_query},
+                    headers={"User-Agent": "LyoLearningAround/1.0 (https://lyoai.app)"},
+                )
+                response.raise_for_status()
+                elements = response.json().get("elements", [])
+        except Exception as exc:  # Nearby Lyo nodes remain available on provider failure.
+            logger.warning("Educational place lookup failed: %s", exc)
+            return []
+
+        nodes: list[LearningNode] = []
+        for element in elements:
+            tags = element.get("tags") or {}
+            center = element.get("center") or {}
+            point_lat = element["lat"] if "lat" in element else center.get("lat")
+            point_lng = element["lon"] if "lon" in element else center.get("lon")
+            if point_lat is None or point_lng is None:
+                continue
+            category = self._place_category(tags)
+            name = tags.get("name") or tags.get("operator")
+            if category is None or not name:
+                continue
+            node_id = f"osm:{element.get('type', 'node')}:{element.get('id')}"
+            address = self._place_address(tags)
+            description = tags.get("description") or tags.get("operator")
+            nodes.append(
+                LearningNode(
+                    key=f"{LearningNodeKind.INSTITUTION.value}:{node_id}",
+                    kind=LearningNodeKind.INSTITUTION,
+                    category=category,
+                    id=node_id,
+                    title=name,
+                    description=description,
+                    latitude=float(point_lat),
+                    longitude=float(point_lng),
+                    distance_km=round(
+                        _haversine_km(latitude, longitude, float(point_lat), float(point_lng)),
+                        2,
+                    ),
+                    location_name=address,
+                    source="openstreetmap",
+                    source_url=(
+                        f"https://www.openstreetmap.org/{element.get('type', 'node')}/"
+                        f"{element.get('id')}"
+                    ),
+                )
+            )
+
+        # Overpass may return the same feature through overlapping tag clauses.
+        deduplicated = list({node.key: node for node in nodes}.values())
+        deduplicated.sort(key=lambda node: node.distance_km or float("inf"))
+        deduplicated = deduplicated[:100]
+        self._poi_cache[cache_key] = (time.monotonic(), deduplicated)
+        return [node.model_copy(deep=True) for node in deduplicated]
+
+    @staticmethod
+    def _place_category(tags: dict) -> Optional[LearningNodeCategory]:
+        if tags.get("tourism") == "museum":
+            return LearningNodeCategory.MUSEUM
+        if tags.get("amenity") == "library":
+            return LearningNodeCategory.LIBRARY
+        if tags.get("amenity") in {
+            "college",
+            "university",
+            "school",
+            "language_school",
+            "music_school",
+            "community_centre",
+        }:
+            return LearningNodeCategory.EDUCATIONAL_CENTER
+        return None
+
+    @staticmethod
+    def _place_address(tags: dict) -> Optional[str]:
+        street = " ".join(
+            value for value in [tags.get("addr:housenumber"), tags.get("addr:street")] if value
+        )
+        locality = tags.get("addr:city") or tags.get("addr:town") or tags.get("addr:suburb")
+        values = [value for value in [street, locality] if value]
+        return ", ".join(values) or None
+
+
+learning_around_service = LearningAroundService()

--- a/lyo_app/community/models.py
+++ b/lyo_app/community/models.py
@@ -7,7 +7,20 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey, Enum as SQLEnum, Float, Uuid, JSON
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum as SQLEnum,
+    Float,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 import uuid
 
@@ -40,6 +53,8 @@ class EventType(str, Enum):
     """Community event type enumeration."""
     STUDY_SESSION = "study_session"
     WORKSHOP = "workshop"
+    CLASS = "class"
+    SEMINAR = "seminar"
     LECTURE = "lecture"
     DISCUSSION = "discussion"
     PROJECT_SHOWCASE = "project_showcase"
@@ -82,6 +97,15 @@ class StudyGroup(Base):
     # Group settings
     max_members = Column(Integer, nullable=True)  # None means unlimited
     requires_approval = Column(Boolean, nullable=False, default=False)
+
+    # Discovery / meeting location. These fields belong to the group itself so
+    # every client sees the same map node after signing in on another device.
+    location = Column(String(300), nullable=True)
+    is_online = Column(Boolean, nullable=False, default=False)
+    meeting_url = Column(String(500), nullable=True)
+    latitude = Column(Float, nullable=True, index=True)
+    longitude = Column(Float, nullable=True, index=True)
+    image_url = Column(String(500), nullable=True)
     
     # Associations
     course_id = Column(Integer, ForeignKey("courses.id"), nullable=True, index=True)
@@ -345,6 +369,9 @@ class PrivateLesson(Base):
     location = Column(String(500), nullable=True)
     latitude = Column(Float, nullable=True)
     longitude = Column(Float, nullable=True)
+    is_online = Column(Boolean, nullable=False, default=False)
+    meeting_url = Column(String(500), nullable=True)
+    image_url = Column(String(500), nullable=True)
 
     # Status
     is_active = Column(Boolean, nullable=False, default=True)
@@ -412,6 +439,37 @@ class Review(Base):
 
     # Relationships
     author = relationship("User", foreign_keys=[author_id], lazy="noload")
+
+
+class CommunitySavedNode(Base):
+    """A map node saved to a Lyo account, never to one device.
+
+    ``node_kind`` and ``node_id`` form a stable polymorphic reference for
+    Lyo-owned events, groups, lessons, and externally sourced institutions.
+    The snapshot keeps external places useful even if the provider is
+    temporarily unavailable when another platform loads My Community.
+    """
+
+    __tablename__ = "community_saved_nodes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    node_kind = Column(String(50), nullable=False, index=True)
+    node_id = Column(String(255), nullable=False, index=True)
+    snapshot = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    user = relationship("User", foreign_keys=[user_id], lazy="noload")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "node_kind",
+            "node_id",
+            name="uq_community_saved_node_user_kind_id",
+        ),
+    )
 
 
 # =============================================================================

--- a/lyo_app/community/routes.py
+++ b/lyo_app/community/routes.py
@@ -3,10 +3,11 @@ Community API routes for study groups and community events.
 Provides RESTful endpoints for collaborative learning features.
 """
 
-from typing import List, Optional
+import logging
+from typing import List, Optional, Set
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from lyo_app.core.database import get_db
@@ -23,15 +24,130 @@ from lyo_app.community.schemas import (
     MarketplaceItemCreate, MarketplaceItemUpdate, MarketplaceItemRead,
     PrivateLessonCreate, PrivateLessonRead,
     BookingCreate, BookingRead, BookingSlotRead,
-    ReviewCreate, ReviewRead, ReviewStatsRead
+    ReviewCreate, ReviewRead, ReviewStatsRead,
+    CommunityMeResponse, LearningNode, LearningNodeCategory,
+    LearningNodeKind, LearningNodeSaveRequest, NearbyLearningResponse,
 )
 from lyo_app.community.models import StudyGroupPrivacy, EventType, AttendanceStatus
+from lyo_app.community.learning_around import learning_around_service
+from lyo_app.services.conversation_sync import conversation_sync_service
 from lyo_app.stack import crud as stack_crud
 from lyo_app.stack.models import StackItemType
 import uuid
 
 router = APIRouter()
 community_service = CommunityService()
+logger = logging.getLogger(__name__)
+
+
+async def _notify_community_change(user_id: int, action: str, **data) -> None:
+    """Best-effort refresh signal; the database remains the source of truth."""
+    try:
+        await conversation_sync_service.sync_community_update(
+            user_id,
+            {"action": action, **data},
+        )
+    except Exception as exc:  # A sync outage must never roll back account state.
+        logger.warning("Could not broadcast Community update for user %s: %s", user_id, exc)
+
+
+@router.get("/nearby", response_model=NearbyLearningResponse)
+async def get_nearby_learning(
+    lat: float = Query(..., ge=-90, le=90),
+    lng: float = Query(..., ge=-180, le=180),
+    radius_km: float = Query(15.0, gt=0, le=100),
+    categories: Optional[str] = Query(
+        None,
+        description="Comma-separated categories: event, workshop, class, study_group, tutor, library, museum, educational_center",
+    ),
+    q: Optional[str] = Query(None, max_length=200),
+    include_online: bool = Query(True),
+    include_institutions: bool = Query(True),
+    limit: int = Query(100, ge=1, le=250),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the canonical, user-aware Learning Around Me map nodes."""
+    parsed_categories: Optional[Set[LearningNodeCategory]] = None
+    if categories:
+        try:
+            parsed_categories = {
+                LearningNodeCategory(value.strip())
+                for value in categories.split(",")
+                if value.strip()
+            }
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown learning node category: {exc}",
+            ) from exc
+    return await learning_around_service.get_nearby(
+        db,
+        user_id=current_user.id,
+        latitude=lat,
+        longitude=lng,
+        radius_km=radius_km,
+        categories=parsed_categories,
+        query_text=q,
+        include_online=include_online,
+        include_institutions=include_institutions,
+        limit=limit,
+    )
+
+
+@router.get("/me", response_model=CommunityMeResponse)
+async def get_my_community_state(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Account-owned groups, events, saves, and people followed by this user."""
+    return await learning_around_service.get_my_community(db, current_user.id)
+
+
+@router.put("/saved-nodes/{kind}/{node_id}", response_model=LearningNode)
+async def save_learning_node(
+    kind: LearningNodeKind,
+    payload: LearningNodeSaveRequest,
+    node_id: str = Path(..., min_length=1, max_length=255),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Save a map node to the authenticated Lyo account idempotently."""
+    try:
+        node = await learning_around_service.save_node(
+            db,
+            user_id=current_user.id,
+            kind=kind,
+            node_id=node_id,
+            snapshot=payload.snapshot,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    await _notify_community_change(current_user.id, "node_saved", node_key=node.key)
+    return node
+
+
+@router.delete("/saved-nodes/{kind}/{node_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def unsave_learning_node(
+    kind: LearningNodeKind,
+    node_id: str = Path(..., min_length=1, max_length=255),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a saved node from the authenticated Lyo account."""
+    removed = await learning_around_service.unsave_node(
+        db,
+        user_id=current_user.id,
+        kind=kind,
+        node_id=node_id,
+    )
+    if not removed:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved node not found")
+    await _notify_community_change(
+        current_user.id,
+        "node_unsaved",
+        node_key=f"{kind.value}:{node_id}",
+    )
 
 
 # Study Group Endpoints
@@ -47,6 +163,11 @@ async def create_study_group(
             db=db, 
             creator_id=current_user.id, 
             group_data=group_data
+        )
+        await _notify_community_change(
+            current_user.id,
+            "study_group_created",
+            group_id=study_group.id,
         )
         return study_group
     except ValueError as e:
@@ -120,9 +241,16 @@ async def update_study_group(
         )
         if not study_group:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Study group not found")
+        await _notify_community_change(
+            current_user.id,
+            "study_group_updated",
+            group_id=group_id,
+        )
         return study_group
-    except ValueError as e:
+    except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
@@ -144,8 +272,15 @@ async def delete_study_group(
         )
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Study group not found or access denied")
-    except ValueError as e:
+        await _notify_community_change(
+            current_user.id,
+            "study_group_deleted",
+            group_id=group_id,
+        )
+    except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
@@ -167,7 +302,14 @@ async def join_study_group(
             user_id=current_user.id,
             membership_data=membership_data
         )
+        await _notify_community_change(
+            current_user.id,
+            "study_group_joined",
+            group_id=group_id,
+        )
         return membership
+    except PermissionError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -189,6 +331,11 @@ async def leave_study_group(
         )
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
+        await _notify_community_change(
+            current_user.id,
+            "study_group_left",
+            group_id=group_id,
+        )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
@@ -215,7 +362,7 @@ async def get_group_members(
             limit=limit
         )
         return members
-    except ValueError as e:
+    except (ValueError, PermissionError) as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to fetch group members")
@@ -241,7 +388,7 @@ async def update_group_membership(
         if not membership:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
         return membership
-    except ValueError as e:
+    except (ValueError, PermissionError) as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except HTTPException:
         raise
@@ -288,7 +435,14 @@ async def create_community_event(
             organizer_id=current_user.id,
             event_data=event_data
         )
+        await _notify_community_change(
+            current_user.id,
+            "event_created",
+            event_id=event.id,
+        )
         return event
+    except PermissionError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -364,9 +518,16 @@ async def update_community_event(
         )
         if not event:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        await _notify_community_change(
+            current_user.id,
+            "event_updated",
+            event_id=event_id,
+        )
         return event
-    except ValueError as e:
+    except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
@@ -388,8 +549,15 @@ async def delete_community_event(
         )
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found or access denied")
-    except ValueError as e:
+        await _notify_community_change(
+            current_user.id,
+            "event_deleted",
+            event_id=event_id,
+        )
+    except PermissionError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
@@ -411,7 +579,14 @@ async def register_event_attendance(
             user_id=current_user.id,
             attendance_data=attendance_data
         )
+        await _notify_community_change(
+            current_user.id,
+            "event_attending",
+            event_id=event_id,
+        )
         return attendance
+    except PermissionError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
@@ -436,6 +611,11 @@ async def update_event_attendance(
         )
         if not attendance:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attendance record not found")
+        await _notify_community_change(
+            current_user.id,
+            "event_attendance_updated",
+            event_id=event_id,
+        )
         return attendance
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
@@ -459,6 +639,11 @@ async def leave_event(
     )
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attendance not found")
+    await _notify_community_change(
+        current_user.id,
+        "event_left",
+        event_id=event_id,
+    )
 
 
 # --- Phase 3: Campus Map & Beacons ---
@@ -1104,6 +1289,11 @@ async def create_private_lesson(
             instructor_id=current_user.id,
             lesson_data=lesson_data
         )
+        await _notify_community_change(
+            current_user.id,
+            "private_lesson_created",
+            lesson_id=lesson.id,
+        )
         return lesson
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
@@ -1308,4 +1498,3 @@ async def search_institutions(
 ):
     """Search institutions (stub)."""
     return []
-

--- a/lyo_app/community/schemas.py
+++ b/lyo_app/community/schemas.py
@@ -33,6 +33,12 @@ class StudyGroupBase(BaseModel):
     max_members: Optional[int] = Field(None, ge=2, le=1000, description="Maximum number of members")
     requires_approval: bool = Field(default=False, description="Whether membership requires approval")
     course_id: Optional[int] = Field(None, description="Associated course ID")
+    location: Optional[str] = Field(None, max_length=300, description="Physical meeting location")
+    is_online: bool = Field(default=False, description="Whether this group meets online")
+    meeting_url: Optional[str] = Field(None, max_length=500, description="Online meeting URL")
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    image_url: Optional[str] = Field(None, max_length=500)
 
 
 class StudyGroupCreate(StudyGroupBase):
@@ -49,6 +55,12 @@ class StudyGroupUpdate(BaseModel):
     max_members: Optional[int] = Field(None, ge=2, le=1000)
     requires_approval: Optional[bool] = None
     status: Optional[StudyGroupStatus] = None
+    location: Optional[str] = Field(None, max_length=300)
+    is_online: Optional[bool] = None
+    meeting_url: Optional[str] = Field(None, max_length=500)
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    image_url: Optional[str] = Field(None, max_length=500)
 
 
 class StudyGroupRead(StudyGroupBase):
@@ -106,6 +118,7 @@ class CommunityEventBase(BaseModel):
     description: Optional[str] = Field(None, max_length=2000, description="Event description")
     event_type: EventType = Field(default=EventType.STUDY_SESSION, description="Type of event")
     location: Optional[str] = Field(None, max_length=300, description="Event location")
+    is_online: bool = Field(default=False, description="Whether the event is online")
     meeting_url: Optional[str] = Field(None, max_length=500, description="Virtual meeting URL")
     max_attendees: Optional[int] = Field(None, ge=1, le=10000, description="Maximum attendees")
     start_time: datetime = Field(..., description="Event start time")
@@ -114,8 +127,8 @@ class CommunityEventBase(BaseModel):
     study_group_id: Optional[int] = Field(None, description="Associated study group ID")
     course_id: Optional[int] = Field(None, description="Associated course ID")
     lesson_id: Optional[int] = Field(None, description="Associated lesson ID")
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
     room_id: Optional[str] = None
     image_url: Optional[str] = None
 
@@ -132,12 +145,17 @@ class CommunityEventUpdate(BaseModel):
     description: Optional[str] = Field(None, max_length=2000)
     event_type: Optional[EventType] = None
     location: Optional[str] = Field(None, max_length=300)
+    is_online: Optional[bool] = None
     meeting_url: Optional[str] = Field(None, max_length=500)
     max_attendees: Optional[int] = Field(None, ge=1, le=10000)
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     timezone: Optional[str] = Field(None, max_length=50)
     status: Optional[EventStatus] = None
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    room_id: Optional[str] = Field(None, max_length=100)
+    image_url: Optional[str] = Field(None, max_length=500)
 
 
 class CommunityEventRead(CommunityEventBase):
@@ -160,6 +178,80 @@ class CommunityEventRead(CommunityEventBase):
     user_attendance_status: Optional[AttendanceStatus] = Field(None, description="Current user's attendance status")
     is_full: Optional[bool] = Field(None, description="Whether event is at capacity")
     organizer_profile: Optional[UserPreview] = None
+
+
+# Map-first Community contract shared by iOS, Android, and web.
+class LearningNodeKind(str, Enum):
+    EVENT = "event"
+    STUDY_GROUP = "study_group"
+    PRIVATE_LESSON = "private_lesson"
+    INSTITUTION = "institution"
+
+
+class LearningNodeCategory(str, Enum):
+    EVENT = "event"
+    WORKSHOP = "workshop"
+    CLASS = "class"
+    STUDY_GROUP = "study_group"
+    TUTOR = "tutor"
+    LIBRARY = "library"
+    MUSEUM = "museum"
+    EDUCATIONAL_CENTER = "educational_center"
+
+
+class LearningNode(BaseModel):
+    """One educational opportunity on the Learning Around Me map."""
+
+    key: str = Field(..., min_length=3, max_length=320)
+    kind: LearningNodeKind
+    category: LearningNodeCategory
+    id: str = Field(..., min_length=1, max_length=255)
+    title: str = Field(..., min_length=1, max_length=300)
+    description: Optional[str] = Field(None, max_length=3000)
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    distance_km: Optional[float] = Field(None, ge=0)
+    location_name: Optional[str] = Field(None, max_length=500)
+    is_online: bool = False
+    meeting_url: Optional[str] = Field(None, max_length=1000)
+    starts_at: Optional[datetime] = None
+    ends_at: Optional[datetime] = None
+    timezone: Optional[str] = Field(None, max_length=50)
+    host: Optional[UserPreview] = None
+    member_count: Optional[int] = Field(None, ge=0)
+    attendee_count: Optional[int] = Field(None, ge=0)
+    capacity: Optional[int] = Field(None, ge=1)
+    is_joined: bool = False
+    is_attending: bool = False
+    is_saved: bool = False
+    course_id: Optional[int] = None
+    lesson_id: Optional[int] = None
+    study_group_id: Optional[int] = None
+    image_url: Optional[str] = Field(None, max_length=1000)
+    source: str = Field(default="lyo", max_length=50)
+    source_url: Optional[str] = Field(None, max_length=1000)
+
+
+class NearbyLearningResponse(BaseModel):
+    items: List[LearningNode]
+    center_latitude: float
+    center_longitude: float
+    radius_km: float
+    fetched_at: datetime
+
+
+class LearningNodeSaveRequest(BaseModel):
+    snapshot: LearningNode
+
+
+class CommunityMeResponse(BaseModel):
+    """Canonical account-owned Community state used on every platform."""
+
+    joined_groups: List[StudyGroupRead]
+    attending_events: List[CommunityEventRead]
+    saved_nodes: List[LearningNode]
+    following: List[UserPreview]
+    updated_at: datetime
 
 
 # Event Attendance Schemas
@@ -384,8 +476,11 @@ class PrivateLessonCreate(BaseModel):
     currency: str = Field(default="USD", max_length=10)
     duration_minutes: int = Field(default=60, ge=15, le=480)
     location: Optional[str] = Field(None, max_length=500)
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
+    latitude: Optional[float] = Field(None, ge=-90, le=90)
+    longitude: Optional[float] = Field(None, ge=-180, le=180)
+    is_online: bool = False
+    meeting_url: Optional[str] = Field(None, max_length=500)
+    image_url: Optional[str] = Field(None, max_length=500)
 
 
 class PrivateLessonRead(BaseModel):
@@ -402,6 +497,9 @@ class PrivateLessonRead(BaseModel):
     location: Optional[str] = None
     latitude: Optional[float] = None
     longitude: Optional[float] = None
+    is_online: bool = False
+    meeting_url: Optional[str] = None
+    image_url: Optional[str] = None
     is_active: bool
     instructor_id: int
     instructor_name: Optional[str] = None
@@ -592,4 +690,3 @@ class PaginatedCommentsResponse(BaseModel):
     limit: int
     total_count: int
     total_pages: int
-

--- a/lyo_app/community/service.py
+++ b/lyo_app/community/service.py
@@ -72,6 +72,12 @@ class CommunityService:
             max_members=group_data.max_members,
             requires_approval=group_data.requires_approval,
             course_id=group_data.course_id,
+            location=group_data.location,
+            is_online=group_data.is_online,
+            meeting_url=group_data.meeting_url,
+            latitude=group_data.latitude,
+            longitude=group_data.longitude,
+            image_url=group_data.image_url,
             creator_id=creator_id,
             status=StudyGroupStatus.ACTIVE,
             created_at=datetime.utcnow(),
@@ -79,9 +85,11 @@ class CommunityService:
         )
         
         db.add(db_group)
-        await db.commit()
-        await db.refresh(db_group)
-        
+        # Flush for the generated id, then commit the group and owner row as
+        # one account-level transaction. A platform must never observe a
+        # created group without its creator membership.
+        await db.flush()
+
         # Automatically add creator as owner
         creator_membership = GroupMembership(
             user_id=creator_id,
@@ -95,7 +103,8 @@ class CommunityService:
         
         db.add(creator_membership)
         await db.commit()
-        
+        await db.refresh(db_group)
+
         return db_group
 
     async def get_study_group_by_id(
@@ -191,19 +200,13 @@ class CommunityService:
         if not await self._has_group_permission(db, group_id, user_id, [MembershipRole.OWNER, MembershipRole.ADMIN]):
             raise PermissionError("Insufficient permissions to update this group")
         
-        # Update fields
-        if group_data.name is not None:
-            group.name = group_data.name
-        if group_data.description is not None:
-            group.description = group_data.description
-        if group_data.privacy is not None:
-            group.privacy = group_data.privacy
-        if group_data.max_members is not None:
-            group.max_members = group_data.max_members
-        if group_data.requires_approval is not None:
-            group.requires_approval = group_data.requires_approval
-        if group_data.status is not None:
-            group.status = group_data.status
+        # Only fields explicitly sent by the client are changed. This also
+        # allows a creator to clear an old meeting URL or location.
+        required_group_fields = {"name", "privacy", "requires_approval", "status", "is_online"}
+        for field, value in group_data.model_dump(exclude_unset=True).items():
+            if field in required_group_fields and value is None:
+                raise ValueError(f"{field} cannot be null")
+            setattr(group, field, value)
         
         group.updated_at = datetime.utcnow()
         
@@ -442,6 +445,12 @@ class CommunityService:
                 "max_members": group.max_members,
                 "requires_approval": group.requires_approval,
                 "course_id": group.course_id,
+                "location": group.location,
+                "is_online": group.is_online,
+                "meeting_url": group.meeting_url,
+                "latitude": group.latitude,
+                "longitude": group.longitude,
+                "image_url": group.image_url,
                 "creator_id": group.creator_id,
                 "created_at": group.created_at,
                 "updated_at": group.updated_at,
@@ -496,6 +505,7 @@ class CommunityService:
             description=event_data.description,
             event_type=event_data.event_type,
             location=event_data.location,
+            is_online=event_data.is_online,
             meeting_url=event_data.meeting_url,
             max_attendees=event_data.max_attendees,
             start_time=event_data.start_time,
@@ -505,15 +515,19 @@ class CommunityService:
             study_group_id=event_data.study_group_id,
             course_id=event_data.course_id,
             lesson_id=event_data.lesson_id,
+            latitude=event_data.latitude,
+            longitude=event_data.longitude,
+            room_id=event_data.room_id,
+            image_url=event_data.image_url,
             status=EventStatus.SCHEDULED,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
         )
         
         db.add(db_event)
-        await db.commit()
-        await db.refresh(db_event)
-        
+        # The event and organizer RSVP are a single durable account write.
+        await db.flush()
+
         # Automatically register organizer
         organizer_attendance = EventAttendance(
             user_id=organizer_id,
@@ -524,7 +538,8 @@ class CommunityService:
         
         db.add(organizer_attendance)
         await db.commit()
-        
+        await db.refresh(db_event)
+
         return db_event
 
     async def get_community_event_by_id(
@@ -592,27 +607,21 @@ class CommunityService:
         if end_time <= start_time:
             raise ValueError("End time must be after start time")
         
-        # Update fields
-        if event_data.title is not None:
-            event.title = event_data.title
-        if event_data.description is not None:
-            event.description = event_data.description
-        if event_data.event_type is not None:
-            event.event_type = event_data.event_type
-        if event_data.location is not None:
-            event.location = event_data.location
-        if event_data.meeting_url is not None:
-            event.meeting_url = event_data.meeting_url
-        if event_data.max_attendees is not None:
-            event.max_attendees = event_data.max_attendees
-        if event_data.start_time is not None:
-            event.start_time = event_data.start_time
-        if event_data.end_time is not None:
-            event.end_time = event_data.end_time
-        if event_data.timezone is not None:
-            event.timezone = event_data.timezone
-        if event_data.status is not None:
-            event.status = event_data.status
+        # Apply only explicit changes; optional fields can intentionally be
+        # cleared while untouched fields retain their canonical value.
+        required_event_fields = {
+            "title",
+            "event_type",
+            "is_online",
+            "start_time",
+            "end_time",
+            "timezone",
+            "status",
+        }
+        for field, value in event_data.model_dump(exclude_unset=True).items():
+            if field in required_event_fields and value is None:
+                raise ValueError(f"{field} cannot be null")
+            setattr(event, field, value)
         
         event.updated_at = datetime.utcnow()
         
@@ -1020,6 +1029,7 @@ class CommunityService:
                     "event_type": event.event_type,
                     "status": event.status,
                     "location": event.location,
+                    "is_online": event.is_online,
                     "meeting_url": event.meeting_url,
                     "max_attendees": event.max_attendees,
                     "start_time": event.start_time,
@@ -2344,6 +2354,9 @@ class CommunityService:
             location=lesson_data.location,
             latitude=lesson_data.latitude,
             longitude=lesson_data.longitude,
+            is_online=lesson_data.is_online,
+            meeting_url=lesson_data.meeting_url,
+            image_url=lesson_data.image_url,
             instructor_id=instructor_id,
         )
         db.add(lesson)
@@ -2615,4 +2628,3 @@ class CommunityService:
             "review_count": total,
             "rating_distribution": distribution
         }
-

--- a/lyo_app/services/conversation_sync.py
+++ b/lyo_app/services/conversation_sync.py
@@ -54,6 +54,7 @@ class SyncEventType(str, Enum):
     TYPING_STOPPED = "typing_stopped"
     SESSION_TRANSFERRED = "session_transferred"
     CONTEXT_UPDATED = "context_updated"
+    COMMUNITY_UPDATED = "community_updated"
 
 
 @dataclass
@@ -326,6 +327,23 @@ class ConversationSyncService:
                 data={"is_typing": is_typing}
             ),
             exclude_device=device_id
+        )
+
+    async def sync_community_update(
+        self,
+        user_id: int,
+        data: Dict[str, Any],
+        device_id: str = "server",
+    ) -> None:
+        """Tell every signed-in device to refresh canonical Community state."""
+        await self._broadcast_to_user(
+            user_id=user_id,
+            event=SyncEvent(
+                event_type=SyncEventType.COMMUNITY_UPDATED,
+                user_id=user_id,
+                device_id=device_id,
+                data=data,
+            ),
         )
 
     async def transfer_session(

--- a/tests/community/test_learning_around.py
+++ b/tests/community/test_learning_around.py
@@ -1,0 +1,211 @@
+"""Contract tests for map-first Community and cross-device account state."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest_asyncio
+from fastapi import FastAPI, Header
+from httpx import ASGITransport, AsyncClient
+
+from lyo_app.auth.routes import get_current_user
+from lyo_app.community.routes import router as community_router
+from lyo_app.core.database import get_db
+
+
+ACCOUNT_ONE = {"X-Test-User": "101"}
+ACCOUNT_TWO = {"X-Test-User": "202"}
+
+
+@pytest_asyncio.fixture
+async def community_clients(db_session):
+    """Two platform clients sharing one backend database and account identity."""
+    app = FastAPI()
+    app.include_router(community_router, prefix="/api/v1/community")
+
+    async def override_get_db():
+        yield db_session
+
+    async def override_current_user(x_test_user: int = Header(101)):
+        return SimpleNamespace(id=x_test_user)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    transport = ASGITransport(app=app)
+    async with (
+        AsyncClient(transport=transport, base_url="http://ios") as ios,
+        AsyncClient(transport=transport, base_url="http://android") as android,
+    ):
+        yield ios, android
+
+
+async def test_nearby_returns_geolocated_user_learning_nodes(community_clients):
+    ios, _ = community_clients
+    group_response = await ios.post(
+        "/api/v1/community/study-groups",
+        headers=ACCOUNT_ONE,
+        json={
+            "name": "Brooklyn Biology Study Pod",
+            "description": "Weekly human biology review",
+            "privacy": "public",
+            "location": "Brooklyn Public Library",
+            "latitude": 40.6725,
+            "longitude": -73.9682,
+        },
+    )
+    assert group_response.status_code == 201, group_response.text
+
+    start = datetime.utcnow() + timedelta(days=1)
+    event_response = await ios.post(
+        "/api/v1/community/events",
+        headers=ACCOUNT_ONE,
+        json={
+            "title": "AI Beginners Workshop",
+            "description": "Build a small classifier together",
+            "event_type": "workshop",
+            "location": "Central Library Lab",
+            "latitude": 40.6730,
+            "longitude": -73.9670,
+            "start_time": start.isoformat(),
+            "end_time": (start + timedelta(hours=2)).isoformat(),
+            "timezone": "America/New_York",
+        },
+    )
+    assert event_response.status_code == 201, event_response.text
+    assert event_response.json()["latitude"] == 40.6730
+    assert event_response.json()["longitude"] == -73.9670
+
+    tutor_response = await ios.post(
+        "/api/v1/community/lessons",
+        headers=ACCOUNT_ONE,
+        json={
+            "title": "Biology Tutor Available",
+            "description": "One-on-one exam preparation",
+            "subject": "Biology",
+            "price_per_hour": 25,
+            "location": "Prospect Park",
+            "latitude": 40.6710,
+            "longitude": -73.9700,
+        },
+    )
+    assert tutor_response.status_code == 201, tutor_response.text
+
+    nearby = await ios.get(
+        "/api/v1/community/nearby",
+        headers=ACCOUNT_ONE,
+        params={
+            "lat": 40.6728,
+            "lng": -73.9680,
+            "radius_km": 5,
+            "include_institutions": False,
+        },
+    )
+    assert nearby.status_code == 200, nearby.text
+    body = nearby.json()
+    nodes = {node["title"]: node for node in body["items"]}
+
+    assert nodes["Brooklyn Biology Study Pod"]["category"] == "study_group"
+    assert nodes["Brooklyn Biology Study Pod"]["is_joined"] is True
+    assert nodes["AI Beginners Workshop"]["category"] == "workshop"
+    assert nodes["AI Beginners Workshop"]["is_attending"] is True
+    assert nodes["AI Beginners Workshop"]["distance_km"] < 1
+    assert nodes["Biology Tutor Available"]["category"] == "tutor"
+
+
+async def test_saved_nodes_and_memberships_follow_account_not_device(
+    community_clients,
+):
+    ios, android = community_clients
+    start = datetime.utcnow() + timedelta(days=1)
+    event_response = await ios.post(
+        "/api/v1/community/events",
+        headers=ACCOUNT_ONE,
+        json={
+            "title": "Cross-device Photography Class",
+            "event_type": "lecture",
+            "location": "Photo Lab",
+            "latitude": 40.75,
+            "longitude": -73.99,
+            "start_time": start.isoformat(),
+            "end_time": (start + timedelta(hours=1)).isoformat(),
+            "timezone": "America/New_York",
+        },
+    )
+    assert event_response.status_code == 201, event_response.text
+    event_id = event_response.json()["id"]
+
+    nearby = await ios.get(
+        "/api/v1/community/nearby",
+        headers=ACCOUNT_ONE,
+        params={
+            "lat": 40.75,
+            "lng": -73.99,
+            "radius_km": 2,
+            "include_institutions": False,
+        },
+    )
+    snapshot = next(
+        node for node in nearby.json()["items"] if node["id"] == str(event_id)
+    )
+    save_response = await ios.put(
+        f"/api/v1/community/saved-nodes/event/{event_id}",
+        headers=ACCOUNT_ONE,
+        json={"snapshot": snapshot},
+    )
+    assert save_response.status_code == 200, save_response.text
+    assert save_response.json()["is_saved"] is True
+
+    group_response = await ios.post(
+        "/api/v1/community/study-groups",
+        headers=ACCOUNT_ONE,
+        json={
+            "name": "Cross-device SAT Study Pod",
+            "privacy": "public",
+            "is_online": True,
+        },
+    )
+    assert group_response.status_code == 201, group_response.text
+    group_id = group_response.json()["id"]
+
+    # A separate platform client reads the same server-owned state without
+    # copying local preferences or caches.
+    android_state = await android.get(
+        "/api/v1/community/me",
+        headers=ACCOUNT_ONE,
+    )
+    assert android_state.status_code == 200, android_state.text
+    android_body = android_state.json()
+    assert any(node["key"] == f"event:{event_id}" for node in android_body["saved_nodes"])
+    assert any(event["id"] == event_id for event in android_body["attending_events"])
+    assert any(group["id"] == group_id for group in android_body["joined_groups"])
+
+    # A different account on either platform must not inherit those rows.
+    other_state = await android.get(
+        "/api/v1/community/me",
+        headers=ACCOUNT_TWO,
+    )
+    assert other_state.status_code == 200, other_state.text
+    assert other_state.json()["saved_nodes"] == []
+    assert other_state.json()["attending_events"] == []
+    assert other_state.json()["joined_groups"] == []
+
+
+async def test_saved_node_identity_cannot_be_spoofed(community_clients):
+    ios, _ = community_clients
+    snapshot = {
+        "key": "event:1",
+        "kind": "event",
+        "category": "event",
+        "id": "1",
+        "title": "Identity test",
+        "is_online": False,
+        "is_joined": False,
+        "is_attending": False,
+        "is_saved": False,
+        "source": "lyo",
+    }
+    response = await ios.put(
+        "/api/v1/community/saved-nodes/study_group/1",
+        headers=ACCOUNT_ONE,
+        json={"snapshot": snapshot},
+    )
+    assert response.status_code == 400

--- a/tests/test_chat_blocks_migration.py
+++ b/tests/test_chat_blocks_migration.py
@@ -56,13 +56,17 @@ def test_the_migration_graph_still_has_exactly_one_head():
     assert len(heads) == 1, f"migration graph forked into multiple heads: {heads}"
 
 
-def test_this_migration_is_the_head():
+def test_chat_blocks_migration_remains_in_the_head_lineage():
     from alembic.config import Config
     from alembic.script import ScriptDirectory
 
     root = Path(__file__).resolve().parents[1]
     script = ScriptDirectory.from_config(Config(str(root / "alembic.ini")))
-    assert script.get_heads() == ["chat_blocks_001"]
+    lineage = {
+        revision.revision
+        for revision in script.iterate_revisions(script.get_current_head(), "base")
+    }
+    assert "chat_blocks_001" in lineage
 
 
 def test_no_two_migrations_share_a_revision_id():


### PR DESCRIPTION
## Summary
- add canonical account-scoped `/community/nearby` and `/community/me` APIs
- add user-created learning nodes for events, workshops, classes, groups, tutoring, libraries, museums, and educational centers
- add account-backed save/unsave, join, and attendance state shared across iOS, Android, and web
- add OpenStreetMap educational POI discovery and privacy-aware meeting-link access
- add the Community Learning Around database migration and cross-device isolation tests
- emit account-scoped Community sync updates

## Verification
- focused Community and migration suite: 11 passed
- Python compile check
- `git diff --check`

## Deployment
Railway deploys `main` through its GitHub integration and runs `alembic upgrade head` as the pre-deploy command before the `/health` gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production schema via migration and new authenticated APIs with privacy rules for meeting URLs; large surface area but guarded by tests and fail-soft external POI lookup.
> 
> **Overview**
> Introduces a **shared, account-scoped “Learning Around Me” contract** for iOS, Android, and web: authenticated **`GET /community/nearby`** returns unified `LearningNode` map pins (events, workshops/classes, study groups, tutors, optional OpenStreetMap institutions) with per-user **saved / joined / attending** flags and **distance** filtering; **`GET /community/me`** aggregates joined groups, upcoming events, saved nodes, and follows.
> 
> Adds **`PUT`/`DELETE /community/saved-nodes/{kind}/{node_id}`** backed by a new **`community_saved_nodes`** table (JSON snapshots, unique per user/kind/id). Saved snapshots **strip `meeting_url`**; discovery only exposes meeting links to **joined groups** or **attending users** (lessons never via the map).
> 
> **Alembic `community_map_001`** backfills ORM-only columns on `community_events`, `study_groups`, and `private_lessons` (geo, online flags, images, etc.) and extends PostgreSQL **`eventtype`** with CLASS/SEMINAR/OFFICE_HOURS. Models/schemas/services now persist those fields; group/event creation uses **single transactions** (creator membership / organizer RSVP).
> 
> Existing community mutations emit **`COMMUNITY_UPDATED`** sync events (best-effort). Route handlers distinguish **`PermissionError` vs `ValueError`**; partial PATCH updates use `exclude_unset`. Contract tests cover nearby discovery and cross-device account isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265aa821ed1668542a9274556f4fb35774fe003d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Provide a canonical, map-first Community learning experience with account-owned state shared across platforms.

New Features:
- Add authenticated nearby and account-state Community APIs for discovering events, workshops, classes, study groups, tutoring, and educational institutions.
- Support account-backed saving and cross-device visibility of Community learning nodes.
- Discover nearby libraries, museums, and educational centers through OpenStreetMap data.
- Expose privacy-aware access to online meeting links for eligible participants and members.

Bug Fixes:
- Persist Community location and map metadata through a canonical database migration so created nodes remain available in production.

Enhancements:
- Emit account-scoped Community updates when learning activities, memberships, attendance, or saved nodes change.
- Improve Community create and update operations so related ownership state is committed atomically and optional fields can be explicitly cleared.
- Add validation and isolation coverage for nearby discovery, saved state, and cross-account access.

Tests:
- Add contract tests covering geolocated learning-node discovery, cross-device account state, identity validation, and migration lineage.