### PR TITLE
Fix Community map 500 on legacy data

### DIFF
--- a/alembic/versions/community_map_002_reconcile_schema.py
+++ b/alembic/versions/community_map_002_reconcile_schema.py
@@ -35,14 +35,181 @@ def _indexes(table: str) -> set[str]:
     return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table)}
 
 
+def _primary_key_columns(table: str) -> set[str]:
+    if not _has_table(table):
+        return set()
+    constraint = sa.inspect(op.get_bind()).get_pk_constraint(table)
+    return set(constraint.get("constrained_columns") or [])
+
+
+def _has_unique_identity(table: str) -> bool:
+    identity = {"user_id", "node_kind", "node_id"}
+    inspector = sa.inspect(op.get_bind())
+    for constraint in inspector.get_unique_constraints(table):
+        if set(constraint.get("column_names") or []) == identity:
+            return True
+    return any(
+        index.get("unique")
+        and set(index.get("column_names") or []) == identity
+        for index in inspector.get_indexes(table)
+    )
+
+
 def _add_column(table: str, column: sa.Column) -> None:
     if _has_table(table) and column.name not in _columns(table):
         op.add_column(table, column)
 
 
 def _add_index(table: str, name: str, columns: list[str]) -> None:
-    if _has_table(table) and name not in _indexes(table):
+    if (
+        _has_table(table)
+        and set(columns).issubset(_columns(table))
+        and name not in _indexes(table)
+    ):
         op.create_index(name, table, columns, unique=False)
+
+
+def _create_saved_nodes_table() -> None:
+    op.create_table(
+        "community_saved_nodes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("node_kind", sa.String(50), nullable=False),
+        sa.Column("node_id", sa.String(255), nullable=False),
+        sa.Column("snapshot", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "user_id",
+            "node_kind",
+            "node_id",
+            name="uq_community_saved_node_user_kind_id",
+        ),
+    )
+
+
+def _next_backup_table_name() -> str:
+    base = "community_saved_nodes_partial_backup_002"
+    name = base
+    suffix = 1
+    while _has_table(name):
+        suffix += 1
+        name = f"{base}_{suffix}"
+    return name
+
+
+def _ensure_saved_node_indexes() -> None:
+    for name, columns in (
+        ("ix_community_saved_nodes_id", ["id"]),
+        ("ix_community_saved_nodes_user_id", ["user_id"]),
+        ("ix_community_saved_nodes_node_kind", ["node_kind"]),
+        ("ix_community_saved_nodes_node_id", ["node_id"]),
+    ):
+        _add_index("community_saved_nodes", name, columns)
+
+
+def _strip_backup_keys_and_indexes(table: str) -> None:
+    """Keep backup rows without reserving canonical PostgreSQL index names."""
+    inspector = sa.inspect(op.get_bind())
+    if op.get_bind().dialect.name == "postgresql":
+        for constraint in inspector.get_unique_constraints(table):
+            if constraint.get("name"):
+                op.drop_constraint(constraint["name"], table, type_="unique")
+        primary_key = inspector.get_pk_constraint(table)
+        if primary_key.get("name"):
+            op.drop_constraint(primary_key["name"], table, type_="primary")
+
+    # Explicit index names are schema-wide in both PostgreSQL and SQLite.
+    # The backup is recovery-only, so removing its indexes preserves every row
+    # while freeing the canonical names for the live table.
+    for index in sa.inspect(op.get_bind()).get_indexes(table):
+        if index.get("name"):
+            op.drop_index(index["name"], table_name=table)
+
+
+def _reconcile_saved_nodes_table() -> None:
+    if not _has_table("community_saved_nodes"):
+        _create_saved_nodes_table()
+        _ensure_saved_node_indexes()
+        return
+
+    # Rows without these identity fields (or without an id primary key) cannot
+    # be associated with an account safely. Preserve that table for recovery
+    # and create a working canonical table instead of dropping unknown data.
+    identity_columns = {"id", "user_id", "node_kind", "node_id"}
+    if (
+        not identity_columns.issubset(_columns("community_saved_nodes"))
+        or _primary_key_columns("community_saved_nodes") != {"id"}
+    ):
+        backup_table = _next_backup_table_name()
+        op.rename_table("community_saved_nodes", backup_table)
+        _strip_backup_keys_and_indexes(backup_table)
+        _create_saved_nodes_table()
+        _ensure_saved_node_indexes()
+        return
+
+    _add_column(
+        "community_saved_nodes",
+        sa.Column("snapshot", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+    )
+    # SQLite forbids adding a column with CURRENT_TIMESTAMP to an existing
+    # table. Production PostgreSQL receives the real current-time default;
+    # the constant is only a portable backfill for legacy SQLite databases.
+    timestamp_default = (
+        sa.text("'1970-01-01 00:00:00'")
+        if op.get_bind().dialect.name == "sqlite"
+        else sa.func.now()
+    )
+    _add_column(
+        "community_saved_nodes",
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=timestamp_default),
+    )
+    _add_column(
+        "community_saved_nodes",
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=timestamp_default),
+    )
+
+    if not _has_unique_identity("community_saved_nodes"):
+        # A missing unique constraint may already have admitted duplicate
+        # saves. They represent the same account-owned state, so preserve the
+        # newest id before restoring the invariant.
+        op.execute(
+            sa.text(
+                """
+                DELETE FROM community_saved_nodes
+                WHERE id IN (
+                    SELECT id
+                    FROM (
+                        SELECT
+                            id,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY user_id, node_kind, node_id
+                                ORDER BY id DESC
+                            ) AS duplicate_rank
+                        FROM community_saved_nodes
+                        WHERE user_id IS NOT NULL
+                          AND node_kind IS NOT NULL
+                          AND node_id IS NOT NULL
+                    ) AS duplicate_saves
+                    WHERE duplicate_rank > 1
+                )
+                """
+            )
+        )
+        if op.get_bind().dialect.name == "sqlite":
+            with op.batch_alter_table("community_saved_nodes") as batch_op:
+                batch_op.create_unique_constraint(
+                    "uq_community_saved_node_user_kind_id",
+                    ["user_id", "node_kind", "node_id"],
+                )
+        else:
+            op.create_unique_constraint(
+                "uq_community_saved_node_user_kind_id",
+                "community_saved_nodes",
+                ["user_id", "node_kind", "node_id"],
+            )
+
+    _ensure_saved_node_indexes()
 
 
 def upgrade() -> None:
@@ -76,39 +243,7 @@ def upgrade() -> None:
     _add_column("private_lessons", sa.Column("meeting_url", sa.String(500), nullable=True))
     _add_column("private_lessons", sa.Column("image_url", sa.String(500), nullable=True))
 
-    if not _has_table("community_saved_nodes"):
-        op.create_table(
-            "community_saved_nodes",
-            sa.Column("id", sa.Integer(), primary_key=True),
-            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
-            sa.Column("node_kind", sa.String(50), nullable=False),
-            sa.Column("node_id", sa.String(255), nullable=False),
-            sa.Column("snapshot", sa.JSON(), nullable=False),
-            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
-            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
-            sa.UniqueConstraint(
-                "user_id",
-                "node_kind",
-                "node_id",
-                name="uq_community_saved_node_user_kind_id",
-            ),
-        )
-        op.create_index("ix_community_saved_nodes_id", "community_saved_nodes", ["id"])
-        op.create_index(
-            "ix_community_saved_nodes_user_id",
-            "community_saved_nodes",
-            ["user_id"],
-        )
-        op.create_index(
-            "ix_community_saved_nodes_node_kind",
-            "community_saved_nodes",
-            ["node_kind"],
-        )
-        op.create_index(
-            "ix_community_saved_nodes_node_id",
-            "community_saved_nodes",
-            ["node_id"],
-        )
+    _reconcile_saved_nodes_table()
 
     if op.get_bind().dialect.name == "postgresql":
         op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'OFFICE_HOURS'")

--- a/alembic/versions/community_map_002_reconcile_schema.py
+++ b/alembic/versions/community_map_002_reconcile_schema.py
@@ -1,0 +1,123 @@
+"""Reconcile the production Learning Around Me schema.
+
+Revision ID: community_map_002
+Revises: community_map_001
+Create Date: 2026-08-23
+
+The first map migration was intentionally tolerant of legacy environments.
+This follow-up makes that tolerance observable and repeatable: if a production
+database recorded the earlier revision while retaining partial schema drift,
+the next deploy repairs the canonical account-level map contract.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "community_map_002"
+down_revision = "community_map_001"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(name)
+
+
+def _columns(table: str) -> set[str]:
+    if not _has_table(table):
+        return set()
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(table)}
+
+
+def _indexes(table: str) -> set[str]:
+    if not _has_table(table):
+        return set()
+    return {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table)}
+
+
+def _add_column(table: str, column: sa.Column) -> None:
+    if _has_table(table) and column.name not in _columns(table):
+        op.add_column(table, column)
+
+
+def _add_index(table: str, name: str, columns: list[str]) -> None:
+    if _has_table(table) and name not in _indexes(table):
+        op.create_index(name, table, columns, unique=False)
+
+
+def upgrade() -> None:
+    _add_column(
+        "community_events",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("community_events", sa.Column("latitude", sa.Float(), nullable=True))
+    _add_column("community_events", sa.Column("longitude", sa.Float(), nullable=True))
+    _add_column("community_events", sa.Column("room_id", sa.String(100), nullable=True))
+    _add_column("community_events", sa.Column("image_url", sa.String(500), nullable=True))
+    _add_index("community_events", "ix_community_events_latitude", ["latitude"])
+    _add_index("community_events", "ix_community_events_longitude", ["longitude"])
+
+    _add_column("study_groups", sa.Column("location", sa.String(300), nullable=True))
+    _add_column(
+        "study_groups",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("study_groups", sa.Column("meeting_url", sa.String(500), nullable=True))
+    _add_column("study_groups", sa.Column("latitude", sa.Float(), nullable=True))
+    _add_column("study_groups", sa.Column("longitude", sa.Float(), nullable=True))
+    _add_column("study_groups", sa.Column("image_url", sa.String(500), nullable=True))
+    _add_index("study_groups", "ix_study_groups_latitude", ["latitude"])
+    _add_index("study_groups", "ix_study_groups_longitude", ["longitude"])
+
+    _add_column(
+        "private_lessons",
+        sa.Column("is_online", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    _add_column("private_lessons", sa.Column("meeting_url", sa.String(500), nullable=True))
+    _add_column("private_lessons", sa.Column("image_url", sa.String(500), nullable=True))
+
+    if not _has_table("community_saved_nodes"):
+        op.create_table(
+            "community_saved_nodes",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("node_kind", sa.String(50), nullable=False),
+            sa.Column("node_id", sa.String(255), nullable=False),
+            sa.Column("snapshot", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+            sa.UniqueConstraint(
+                "user_id",
+                "node_kind",
+                "node_id",
+                name="uq_community_saved_node_user_kind_id",
+            ),
+        )
+        op.create_index("ix_community_saved_nodes_id", "community_saved_nodes", ["id"])
+        op.create_index(
+            "ix_community_saved_nodes_user_id",
+            "community_saved_nodes",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_community_saved_nodes_node_kind",
+            "community_saved_nodes",
+            ["node_kind"],
+        )
+        op.create_index(
+            "ix_community_saved_nodes_node_id",
+            "community_saved_nodes",
+            ["node_id"],
+        )
+
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'OFFICE_HOURS'")
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'CLASS'")
+        op.execute("ALTER TYPE eventtype ADD VALUE IF NOT EXISTS 'SEMINAR'")
+
+
+def downgrade() -> None:
+    # This is a repair-only revision. community_map_001 owns the schema and
+    # performs the canonical downgrade; removing repaired production columns
+    # here would make a downgrade from 002 to 001 destructive.
+    pass

--- a/lyo_app/community/learning_around.py
+++ b/lyo_app/community/learning_around.py
@@ -11,8 +11,8 @@ import logging
 import math
 import os
 import time
-from datetime import datetime
-from typing import Optional, Set
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional, Set, TypeVar
 
 import httpx
 from sqlalchemy import and_, or_, select
@@ -46,13 +46,64 @@ from lyo_app.community.schemas import (
 from lyo_app.feeds.models import UserFollow
 
 logger = logging.getLogger(__name__)
+ReadResult = TypeVar("ReadResult")
+
+
+def _clean_text(value: Any, max_length: int) -> Optional[str]:
+    """Return provider/legacy text that is safe for the public map contract."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:max_length] or None
+
+
+def _clean_coordinates(
+    latitude: Any,
+    longitude: Any,
+) -> tuple[Optional[float], Optional[float]]:
+    """Treat corrupt or partial coordinates as unavailable, not a map outage."""
+    try:
+        point_latitude = float(latitude)
+        point_longitude = float(longitude)
+    except (TypeError, ValueError, OverflowError):
+        return None, None
+    if (
+        not math.isfinite(point_latitude)
+        or not math.isfinite(point_longitude)
+        or not -90 <= point_latitude <= 90
+        or not -180 <= point_longitude <= 180
+    ):
+        return None, None
+    return point_latitude, point_longitude
+
+
+def _positive_capacity(value: Any) -> Optional[int]:
+    """Normalize pre-contract zero/negative capacities to unlimited."""
+    try:
+        capacity = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return capacity if capacity >= 1 else None
+
+
+def _start_sort_value(value: Optional[datetime]) -> float:
+    """Sort aware and naive legacy datetimes without comparing them directly."""
+    if value is None:
+        return float("inf")
+    try:
+        normalized = value
+        if value.tzinfo is None or value.utcoffset() is None:
+            normalized = value.replace(tzinfo=timezone.utc)
+        return normalized.timestamp()
+    except (AttributeError, OSError, OverflowError, ValueError):
+        return float("inf")
 
 
 def _display_name(user: Optional[User]) -> str:
     if user is None:
         return ""
     full_name = f"{user.first_name or ''} {user.last_name or ''}".strip()
-    return full_name or user.username
+    return full_name or user.username or "Lyo learner"
 
 
 def _preview(user: Optional[User]) -> Optional[UserPreview]:
@@ -71,6 +122,9 @@ def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
         math.sin(delta_phi / 2) ** 2
         + math.cos(phi1) * math.cos(phi2) * math.sin(delta_lng / 2) ** 2
     )
+    # Floating point rounding can push an antipodal distance just outside
+    # [0, 1], which otherwise raises while building the whole map response.
+    value = min(1.0, max(0.0, value))
     return radius * 2 * math.atan2(math.sqrt(value), math.sqrt(1 - value))
 
 
@@ -118,9 +172,27 @@ class LearningAroundService:
         search = query_text.strip().lower() if query_text else None
         south, north, west, east = _bounds(latitude, longitude, radius_km)
 
-        saved_keys = await self._saved_keys(db, user_id)
-        joined_group_ids = await self._joined_group_ids(db, user_id)
-        attending_event_ids = await self._attending_event_ids(db, user_id)
+        # Account state and map sources are intentionally failure-isolated. A
+        # drifted legacy table or one temporarily unavailable source must not
+        # turn every other source (including public institutions) into a 500.
+        saved_keys = await self._read_or_default(
+            db,
+            "saved nodes",
+            lambda: self._saved_keys(db, user_id),
+            set(),
+        )
+        joined_group_ids = await self._read_or_default(
+            db,
+            "group memberships",
+            lambda: self._joined_group_ids(db, user_id),
+            set(),
+        )
+        attending_event_ids = await self._read_or_default(
+            db,
+            "event attendance",
+            lambda: self._attending_event_ids(db, user_id),
+            set(),
+        )
 
         items: list[LearningNode] = []
 
@@ -136,7 +208,7 @@ class LearningAroundService:
             )
             if include_online:
                 event_location = or_(event_location, CommunityEvent.is_online.is_(True))
-            result = await db.execute(
+            event_statement = (
                 select(CommunityEvent)
                 .options(
                     selectinload(CommunityEvent.organizer),
@@ -150,19 +222,32 @@ class LearningAroundService:
                 .order_by(CommunityEvent.start_time)
                 .limit(max(limit * 2, 100))
             )
-            for event in result.scalars().all():
-                category = _event_category(event.event_type)
-                if category not in categories:
-                    continue
-                node = self._event_node(
-                    event,
-                    latitude,
-                    longitude,
-                    saved_keys,
-                    attending_event_ids,
-                )
-                if self._within_scope(node, radius_km, include_online, search):
-                    items.append(node)
+            events = await self._read_or_default(
+                db,
+                "events",
+                lambda: self._scalar_rows(db, event_statement),
+                [],
+            )
+            for event in events:
+                try:
+                    category = _event_category(event.event_type)
+                    if category not in categories:
+                        continue
+                    node = self._event_node(
+                        event,
+                        latitude,
+                        longitude,
+                        saved_keys,
+                        attending_event_ids,
+                    )
+                    if self._within_scope(node, radius_km, include_online, search):
+                        items.append(node)
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping invalid Community event %s: %s",
+                        getattr(event, "id", "unknown"),
+                        exc,
+                    )
 
         if LearningNodeCategory.STUDY_GROUP in categories:
             group_location = and_(
@@ -171,7 +256,7 @@ class LearningAroundService:
             )
             if include_online:
                 group_location = or_(group_location, StudyGroup.is_online.is_(True))
-            result = await db.execute(
+            group_statement = (
                 select(StudyGroup)
                 .options(
                     selectinload(StudyGroup.creator),
@@ -188,18 +273,33 @@ class LearningAroundService:
                 .order_by(StudyGroup.updated_at.desc())
                 .limit(max(limit * 2, 100))
             )
-            for group in result.scalars().all():
-                member_count = sum(1 for membership in group.memberships if membership.is_approved)
-                node = self._group_node(
-                    group,
-                    latitude,
-                    longitude,
-                    saved_keys,
-                    joined_group_ids,
-                    member_count,
-                )
-                if self._within_scope(node, radius_km, include_online, search):
-                    items.append(node)
+            groups = await self._read_or_default(
+                db,
+                "study groups",
+                lambda: self._scalar_rows(db, group_statement),
+                [],
+            )
+            for group in groups:
+                try:
+                    member_count = sum(
+                        1 for membership in group.memberships if membership.is_approved
+                    )
+                    node = self._group_node(
+                        group,
+                        latitude,
+                        longitude,
+                        saved_keys,
+                        joined_group_ids,
+                        member_count,
+                    )
+                    if self._within_scope(node, radius_km, include_online, search):
+                        items.append(node)
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping invalid Community study group %s: %s",
+                        getattr(group, "id", "unknown"),
+                        exc,
+                    )
 
         if LearningNodeCategory.TUTOR in categories:
             lesson_location = and_(
@@ -208,22 +308,35 @@ class LearningAroundService:
             )
             if include_online:
                 lesson_location = or_(lesson_location, PrivateLesson.is_online.is_(True))
-            result = await db.execute(
+            lesson_statement = (
                 select(PrivateLesson)
                 .options(selectinload(PrivateLesson.instructor))
                 .where(PrivateLesson.is_active.is_(True), lesson_location)
                 .order_by(PrivateLesson.updated_at.desc())
                 .limit(max(limit * 2, 100))
             )
-            for lesson in result.scalars().all():
-                node = self._lesson_node(
-                    lesson,
-                    latitude,
-                    longitude,
-                    saved_keys,
-                )
-                if self._within_scope(node, radius_km, include_online, search):
-                    items.append(node)
+            lessons = await self._read_or_default(
+                db,
+                "private lessons",
+                lambda: self._scalar_rows(db, lesson_statement),
+                [],
+            )
+            for lesson in lessons:
+                try:
+                    node = self._lesson_node(
+                        lesson,
+                        latitude,
+                        longitude,
+                        saved_keys,
+                    )
+                    if self._within_scope(node, radius_km, include_online, search):
+                        items.append(node)
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping invalid Community private lesson %s: %s",
+                        getattr(lesson, "id", "unknown"),
+                        exc,
+                    )
 
         institution_categories = {
             LearningNodeCategory.LIBRARY,
@@ -243,7 +356,7 @@ class LearningAroundService:
             key=lambda item: (
                 item.distance_km is None,
                 item.distance_km if item.distance_km is not None else float("inf"),
-                item.starts_at or datetime.max,
+                _start_sort_value(item.starts_at),
                 item.title.lower(),
             )
         )
@@ -421,6 +534,36 @@ class LearningAroundService:
             return None
         return round(_haversine_km(latitude, longitude, node_latitude, node_longitude), 2)
 
+    @staticmethod
+    async def _scalar_rows(db: AsyncSession, statement: Any) -> list[Any]:
+        result = await db.execute(statement)
+        return list(result.scalars().all())
+
+    @staticmethod
+    async def _read_or_default(
+        db: AsyncSession,
+        source: str,
+        operation: Callable[[], Awaitable[ReadResult]],
+        default: ReadResult,
+    ) -> ReadResult:
+        try:
+            return await operation()
+        except Exception as exc:
+            logger.error(
+                "Community nearby %s read failed; returning a partial map: %s",
+                source,
+                exc,
+                exc_info=True,
+            )
+            try:
+                await db.rollback()
+            except Exception as rollback_exc:
+                logger.error(
+                    "Could not recover Community read transaction: %s",
+                    rollback_exc,
+                )
+            return default
+
     def _event_node(
         self,
         event: CommunityEvent,
@@ -431,22 +574,35 @@ class LearningAroundService:
     ) -> LearningNode:
         node_id = str(event.id)
         key = f"{LearningNodeKind.EVENT.value}:{node_id}"
+        node_latitude, node_longitude = _clean_coordinates(
+            event.latitude,
+            event.longitude,
+        )
         return LearningNode(
             key=key,
             kind=LearningNodeKind.EVENT,
             category=_event_category(event.event_type),
             id=node_id,
-            title=event.title,
-            description=event.description,
-            latitude=event.latitude,
-            longitude=event.longitude,
-            distance_km=self._distance(latitude, longitude, event.latitude, event.longitude),
-            location_name=event.location,
+            title=_clean_text(event.title, 300),
+            description=_clean_text(event.description, 3000),
+            latitude=node_latitude,
+            longitude=node_longitude,
+            distance_km=self._distance(
+                latitude,
+                longitude,
+                node_latitude,
+                node_longitude,
+            ),
+            location_name=_clean_text(event.location, 500),
             is_online=event.is_online,
-            meeting_url=event.meeting_url if event.id in attending_ids else None,
+            meeting_url=(
+                _clean_text(event.meeting_url, 1000)
+                if event.id in attending_ids
+                else None
+            ),
             starts_at=event.start_time,
             ends_at=event.end_time,
-            timezone=event.timezone,
+            timezone=_clean_text(event.timezone, 50),
             host=_preview(event.organizer),
             attendee_count=(
                 sum(
@@ -462,13 +618,13 @@ class LearningAroundService:
                 if "attendances" in event.__dict__
                 else None
             ),
-            capacity=event.max_attendees,
+            capacity=_positive_capacity(event.max_attendees),
             is_attending=event.id in attending_ids,
             is_saved=key in saved_keys,
             course_id=event.course_id,
             lesson_id=event.lesson_id,
             study_group_id=event.study_group_id,
-            image_url=event.image_url,
+            image_url=_clean_text(event.image_url, 1000),
         )
 
     def _group_node(
@@ -482,27 +638,40 @@ class LearningAroundService:
     ) -> LearningNode:
         node_id = str(group.id)
         key = f"{LearningNodeKind.STUDY_GROUP.value}:{node_id}"
+        node_latitude, node_longitude = _clean_coordinates(
+            group.latitude,
+            group.longitude,
+        )
         return LearningNode(
             key=key,
             kind=LearningNodeKind.STUDY_GROUP,
             category=LearningNodeCategory.STUDY_GROUP,
             id=node_id,
-            title=group.name,
-            description=group.description,
-            latitude=group.latitude,
-            longitude=group.longitude,
-            distance_km=self._distance(latitude, longitude, group.latitude, group.longitude),
-            location_name=group.location,
+            title=_clean_text(group.name, 300),
+            description=_clean_text(group.description, 3000),
+            latitude=node_latitude,
+            longitude=node_longitude,
+            distance_km=self._distance(
+                latitude,
+                longitude,
+                node_latitude,
+                node_longitude,
+            ),
+            location_name=_clean_text(group.location, 500),
             is_online=group.is_online,
-            meeting_url=group.meeting_url if group.id in joined_ids else None,
+            meeting_url=(
+                _clean_text(group.meeting_url, 1000)
+                if group.id in joined_ids
+                else None
+            ),
             host=_preview(group.creator),
             member_count=member_count,
-            capacity=group.max_members,
+            capacity=_positive_capacity(group.max_members),
             is_joined=group.id in joined_ids,
             is_saved=key in saved_keys,
             course_id=group.course_id,
             study_group_id=group.id,
-            image_url=group.image_url,
+            image_url=_clean_text(group.image_url, 1000),
         )
 
     def _lesson_node(
@@ -514,26 +683,46 @@ class LearningAroundService:
     ) -> LearningNode:
         node_id = str(lesson.id)
         key = f"{LearningNodeKind.PRIVATE_LESSON.value}:{node_id}"
-        price = f"{lesson.currency} {lesson.price_per_hour:g}/hour"
-        description = " · ".join(value for value in [lesson.subject, price, lesson.description] if value)
+        node_latitude, node_longitude = _clean_coordinates(
+            lesson.latitude,
+            lesson.longitude,
+        )
+        price = None
+        if lesson.price_per_hour is not None:
+            try:
+                amount = f"{lesson.price_per_hour:g}"
+            except (TypeError, ValueError):
+                amount = str(lesson.price_per_hour)
+            currency = _clean_text(lesson.currency, 20)
+            price = f"{currency} {amount}/hour" if currency else f"{amount}/hour"
+        description = " · ".join(
+            str(value)
+            for value in [lesson.subject, price, lesson.description]
+            if value
+        )
         return LearningNode(
             key=key,
             kind=LearningNodeKind.PRIVATE_LESSON,
             category=LearningNodeCategory.TUTOR,
             id=node_id,
-            title=lesson.title,
-            description=description,
-            latitude=lesson.latitude,
-            longitude=lesson.longitude,
-            distance_km=self._distance(latitude, longitude, lesson.latitude, lesson.longitude),
-            location_name=lesson.location,
+            title=_clean_text(lesson.title, 300),
+            description=_clean_text(description, 3000),
+            latitude=node_latitude,
+            longitude=node_longitude,
+            distance_km=self._distance(
+                latitude,
+                longitude,
+                node_latitude,
+                node_longitude,
+            ),
+            location_name=_clean_text(lesson.location, 500),
             is_online=lesson.is_online,
             # The public map advertises the lesson; the private meeting link is
             # released through the booking flow, never through discovery.
             meeting_url=None,
             host=_preview(lesson.instructor),
             is_saved=key in saved_keys,
-            image_url=lesson.image_url,
+            image_url=_clean_text(lesson.image_url, 1000),
         )
 
     async def _saved_keys(self, db: AsyncSession, user_id: int) -> Set[str]:
@@ -605,41 +794,59 @@ class LearningAroundService:
 
         nodes: list[LearningNode] = []
         for element in elements:
-            tags = element.get("tags") or {}
-            center = element.get("center") or {}
-            point_lat = element["lat"] if "lat" in element else center.get("lat")
-            point_lng = element["lon"] if "lon" in element else center.get("lon")
-            if point_lat is None or point_lng is None:
-                continue
-            category = self._place_category(tags)
-            name = tags.get("name") or tags.get("operator")
-            if category is None or not name:
-                continue
-            node_id = f"osm:{element.get('type', 'node')}:{element.get('id')}"
-            address = self._place_address(tags)
-            description = tags.get("description") or tags.get("operator")
-            nodes.append(
-                LearningNode(
-                    key=f"{LearningNodeKind.INSTITUTION.value}:{node_id}",
-                    kind=LearningNodeKind.INSTITUTION,
-                    category=category,
-                    id=node_id,
-                    title=name,
-                    description=description,
-                    latitude=float(point_lat),
-                    longitude=float(point_lng),
-                    distance_km=round(
-                        _haversine_km(latitude, longitude, float(point_lat), float(point_lng)),
-                        2,
-                    ),
-                    location_name=address,
-                    source="openstreetmap",
-                    source_url=(
-                        f"https://www.openstreetmap.org/{element.get('type', 'node')}/"
-                        f"{element.get('id')}"
-                    ),
+            try:
+                if not isinstance(element, dict):
+                    continue
+                tags = element.get("tags") or {}
+                center = element.get("center") or {}
+                if not isinstance(tags, dict) or not isinstance(center, dict):
+                    continue
+                point_lat = element["lat"] if "lat" in element else center.get("lat")
+                point_lng = element["lon"] if "lon" in element else center.get("lon")
+                point_lat, point_lng = _clean_coordinates(point_lat, point_lng)
+                if point_lat is None or point_lng is None:
+                    continue
+                category = self._place_category(tags)
+                name = _clean_text(tags.get("name") or tags.get("operator"), 300)
+                if category is None or not name:
+                    continue
+                element_type = _clean_text(element.get("type"), 20) or "node"
+                element_id = _clean_text(element.get("id"), 220)
+                if not element_id:
+                    continue
+                node_id = f"osm:{element_type}:{element_id}"
+                address = self._place_address(tags)
+                description = _clean_text(
+                    tags.get("description") or tags.get("operator"),
+                    3000,
                 )
-            )
+                nodes.append(
+                    LearningNode(
+                        key=f"{LearningNodeKind.INSTITUTION.value}:{node_id}",
+                        kind=LearningNodeKind.INSTITUTION,
+                        category=category,
+                        id=node_id,
+                        title=name,
+                        description=description,
+                        latitude=point_lat,
+                        longitude=point_lng,
+                        distance_km=round(
+                            _haversine_km(latitude, longitude, point_lat, point_lng),
+                            2,
+                        ),
+                        location_name=address,
+                        source="openstreetmap",
+                        source_url=(
+                            f"https://www.openstreetmap.org/{element_type}/{element_id}"
+                        ),
+                    )
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Skipping invalid educational place %s: %s",
+                    element.get("id", "unknown") if isinstance(element, dict) else "unknown",
+                    exc,
+                )
 
         # Overpass may return the same feature through overlapping tag clauses.
         deduplicated = list({node.key: node for node in nodes}.values())
@@ -668,11 +875,13 @@ class LearningAroundService:
     @staticmethod
     def _place_address(tags: dict) -> Optional[str]:
         street = " ".join(
-            value for value in [tags.get("addr:housenumber"), tags.get("addr:street")] if value
+            str(value)
+            for value in [tags.get("addr:housenumber"), tags.get("addr:street")]
+            if value
         )
         locality = tags.get("addr:city") or tags.get("addr:town") or tags.get("addr:suburb")
-        values = [value for value in [street, locality] if value]
-        return ", ".join(values) or None
+        values = [str(value) for value in [street, locality] if value]
+        return _clean_text(", ".join(values), 500)
 
 
 learning_around_service = LearningAroundService()

--- a/tests/community/test_learning_around.py
+++ b/tests/community/test_learning_around.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI, Header
 from httpx import ASGITransport, AsyncClient
 
 from lyo_app.auth.routes import get_current_user
+from lyo_app.community.learning_around import LearningAroundService
+from lyo_app.community.models import EventType
 from lyo_app.community.routes import router as community_router
 from lyo_app.core.database import get_db
 
@@ -109,6 +111,44 @@ async def test_nearby_returns_geolocated_user_learning_nodes(community_clients):
     assert nodes["AI Beginners Workshop"]["is_attending"] is True
     assert nodes["AI Beginners Workshop"]["distance_km"] < 1
     assert nodes["Biology Tutor Available"]["category"] == "tutor"
+
+
+def test_nearby_normalizes_legacy_rows_instead_of_returning_500():
+    """Pre-contract data must not make the cross-platform map all-or-nothing."""
+    start = datetime.utcnow() + timedelta(days=1)
+    legacy_event = SimpleNamespace(
+        id=42,
+        title="Legacy capacity workshop",
+        description="x" * 3501,
+        event_type=EventType.WORKSHOP,
+        location="Online",
+        is_online=True,
+        meeting_url=None,
+        latitude=999,
+        longitude=-999,
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+        timezone="UTC",
+        max_attendees=0,
+        organizer=None,
+        attendances=[],
+        course_id=None,
+        lesson_id=None,
+        study_group_id=None,
+        image_url=None,
+    )
+    node = LearningAroundService()._event_node(
+        legacy_event,
+        latitude=40.75,
+        longitude=-73.99,
+        saved_keys=set(),
+        attending_ids=set(),
+    )
+
+    assert len(node.description) == 3000
+    assert node.capacity is None
+    assert node.latitude is None
+    assert node.longitude is None
 
 
 async def test_saved_nodes_and_memberships_follow_account_not_device(

--- a/tests/test_community_map_migration.py
+++ b/tests/test_community_map_migration.py
@@ -1,0 +1,154 @@
+"""Regression tests for the production Community map repair migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "community_map_002_reconcile_schema.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("community_map_002", MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _with_ops(connection, function):
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        function()
+
+
+def _create_map_tables(connection):
+    connection.execute(sa.text("CREATE TABLE users (id INTEGER PRIMARY KEY)"))
+    connection.execute(sa.text("CREATE TABLE community_events (id INTEGER PRIMARY KEY)"))
+    connection.execute(sa.text("CREATE TABLE study_groups (id INTEGER PRIMARY KEY)"))
+    connection.execute(sa.text("CREATE TABLE private_lessons (id INTEGER PRIMARY KEY)"))
+
+
+def test_upgrade_repairs_an_existing_partial_saved_node_table():
+    module = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        _create_map_tables(connection)
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE community_saved_nodes (
+                    id INTEGER PRIMARY KEY,
+                    user_id INTEGER NOT NULL,
+                    node_kind VARCHAR(50) NOT NULL,
+                    node_id VARCHAR(255) NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO community_saved_nodes (id, user_id, node_kind, node_id)
+                VALUES
+                    (1, 7, 'event', '42'),
+                    (2, 7, 'event', '42')
+                """
+            )
+        )
+
+        _with_ops(connection, module.upgrade)
+        _with_ops(connection, module.upgrade)
+
+        inspector = sa.inspect(connection)
+        columns = {
+            column["name"]
+            for column in inspector.get_columns("community_saved_nodes")
+        }
+        assert {
+            "id",
+            "user_id",
+            "node_kind",
+            "node_id",
+            "snapshot",
+            "created_at",
+            "updated_at",
+        }.issubset(columns)
+        assert {
+            "ix_community_saved_nodes_id",
+            "ix_community_saved_nodes_user_id",
+            "ix_community_saved_nodes_node_kind",
+            "ix_community_saved_nodes_node_id",
+        }.issubset(
+            {index["name"] for index in inspector.get_indexes("community_saved_nodes")}
+        )
+        assert connection.scalar(
+            sa.text("SELECT COUNT(*) FROM community_saved_nodes")
+        ) == 1
+
+        with pytest.raises(sa.exc.IntegrityError):
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO community_saved_nodes (
+                        id, user_id, node_kind, node_id, snapshot
+                    ) VALUES (3, 7, 'event', '42', '{}')
+                    """
+                )
+            )
+
+
+def test_upgrade_preserves_an_unidentifiable_partial_table_as_a_backup():
+    module = _load_migration()
+    engine = sa.create_engine("sqlite://")
+
+    with engine.begin() as connection:
+        _create_map_tables(connection)
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE community_saved_nodes (
+                    id INTEGER PRIMARY KEY,
+                    snapshot JSON
+                )
+                """
+            )
+        )
+        connection.execute(
+            sa.text("INSERT INTO community_saved_nodes (id, snapshot) VALUES (1, '{}')")
+        )
+        connection.execute(
+            sa.text(
+                "CREATE INDEX ix_community_saved_nodes_id "
+                "ON community_saved_nodes (id)"
+            )
+        )
+
+        _with_ops(connection, module.upgrade)
+
+        inspector = sa.inspect(connection)
+        assert inspector.has_table("community_saved_nodes")
+        assert inspector.has_table("community_saved_nodes_partial_backup_002")
+        assert connection.scalar(
+            sa.text("SELECT COUNT(*) FROM community_saved_nodes_partial_backup_002")
+        ) == 1
+        assert {
+            "id",
+            "user_id",
+            "node_kind",
+            "node_id",
+            "snapshot",
+            "created_at",
+            "updated_at",
+        } == {
+            column["name"]
+            for column in inspector.get_columns("community_saved_nodes")
+        }


### PR DESCRIPTION
## Summary
- normalize legacy Community map records before response validation
- isolate account and learning-node sources so one failed source returns a partial map instead of HTTP 500
- skip malformed external institution records without losing valid nearby places
- reconcile partially applied production map schema at deploy time

## Verification
- `pytest -q tests/community/` — 51 passed
- fatal Python lint checks — passed
- migration graph — one head: `community_map_002`
- reconciliation migration — repaired a deliberately partial schema and advanced to `community_map_002`

The canonical saved-node, membership, and attendance state remains backend-owned and shared across iOS, Android, and web.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production schema repair (including duplicate-row deletes and table rename/backup) and swallows per-source DB errors so the map can return partial results. Not auth/payment, but deploy-time data mutation is non-trivial.
> 
> **Overview**
> Stops the Community nearby map from failing entirely when production schema is drifted or a single source/row is invalid. Callers get a **partial map** instead of HTTP 500.
> 
> **Reads** isolate saved nodes, memberships, attendance, events, groups, and lessons behind `_read_or_default` (rollback on failure). Invalid rows and OSM places are skipped after sanitizing text, coordinates, capacity, and sort timestamps.
> 
> **Deploy** adds idempotent `community_map_002`: fills missing geo/online columns, restores `community_saved_nodes` (or backs up unidentifiable tables), dedupes saves before the unique constraint, and extends the Postgres `eventtype` enum. Downgrade is a no-op so 002→001 is not destructive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3524a42245e46618a10c67a92b1542e57a321e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Harden the Community nearby map against legacy data and production schema drift while preserving usable partial results.

Bug Fixes:
- Prevent Community nearby-map requests from failing with HTTP 500 when legacy or malformed records are encountered.
- Return partial map results when individual account, database, or external institution sources fail.
- Skip invalid external institution data while preserving valid nearby places.

Enhancements:
- Normalize legacy map data before response validation, including text, coordinates, capacities, and datetime values.

Deployment:
- Add an idempotent migration to reconcile drifted Community map schema, restore saved-node constraints and indexes, preserve unrecoverable partial data in backups, and add missing event enum values.

Tests:
- Add regression coverage for legacy map-record normalization and production schema repair behavior.